### PR TITLE
Add Solana verifier and address

### DIFF
--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -117,6 +117,11 @@ export const DopplerVerifierAddress: Addresses = {
   [baseSepolia.id]: "0x6428b5C4da36ecB070aBdcB5E1939244A3cC7fb5",
 };
 
+export const SolanaVerifierAddress: Addresses = {
+  [base.id]: "0xba28ac1540893a34476c24b2c4fa32e0506c9055",
+  [baseSepolia.id]: "0x47226918e518f205584bd75bf81e0b532b0b3ea7",
+};
+
 export const VirtualsVerifierAddress: Addresses = {
   [base.id]: "0x06a089fa231aca48d2aa77365123ad9aca43d3a4",
   [baseSepolia.id]: "0x6582d2bc6a7eba3b40bdf46b3868fc7ec2ff96ec",

--- a/src/clients/TokenImporter.ts
+++ b/src/clients/TokenImporter.ts
@@ -14,6 +14,7 @@ import { Verifier } from "../types";
 import {
   ClankerWorldVerifierAddress,
   DopplerVerifierAddress,
+  SolanaVerifierAddress,
   VirtualsVerifierAddress,
   WhitelistVerifierAddress,
   ZoraVerifierAddress,
@@ -68,6 +69,8 @@ export class ReadTokenImporter {
         return ClankerWorldVerifierAddress[this.chainId];
       case Verifier.DOPPLER:
         return DopplerVerifierAddress[this.chainId];
+      case Verifier.SOLANA:
+        return SolanaVerifierAddress[this.chainId];
       case Verifier.VIRTUALS:
         return VirtualsVerifierAddress[this.chainId];
       case Verifier.WHITELIST:

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export enum FlaunchVersion {
 export enum Verifier {
   CLANKER = "clanker",
   DOPPLER = "doppler",
+  SOLANA = "solana",
   VIRTUALS = "virtuals",
   WHITELIST = "whitelist",
   ZORA = "zora",


### PR DESCRIPTION
It looks like the previous Solana verification logic is missing from the release:
https://github.com/flayerlabs/flaunch-sdk/commit/f0859bec6b893110350f24a9483028f5e7715b38

This PR adds it back in and also updates the Base address to be correct.