### PR TITLE
Add totalSupply into the single sided add liquidity

### DIFF
--- a/src/abi/TokenImporter.ts
+++ b/src/abi/TokenImporter.ts
@@ -1,276 +1,403 @@
 export const TokenImporterAbi = [
-  {
-    type: "constructor",
-    inputs: [
-      {
-        name: "_anyPositionManager",
-        type: "address",
-        internalType: "address payable",
-      },
-    ],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "addVerifier",
-    inputs: [{ name: "_verifier", type: "address", internalType: "address" }],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "anyPositionManager",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "contract AnyPositionManager",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "cancelOwnershipHandover",
-    inputs: [],
-    outputs: [],
-    stateMutability: "payable",
-  },
-  {
-    type: "function",
-    name: "completeOwnershipHandover",
-    inputs: [
-      { name: "pendingOwner", type: "address", internalType: "address" },
-    ],
-    outputs: [],
-    stateMutability: "payable",
-  },
-  {
-    type: "function",
-    name: "getAllVerifiers",
-    inputs: [],
-    outputs: [
-      {
-        name: "verifiers_",
-        type: "address[]",
-        internalType: "address[]",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "initialize",
-    inputs: [
-      { name: "_memecoin", type: "address", internalType: "address" },
-      {
-        name: "_creatorFeeAllocation",
-        type: "uint24",
-        internalType: "uint24",
-      },
-      {
-        name: "_initialMarketCap",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      { name: "_verifier", type: "address", internalType: "address" },
-    ],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "initialize",
-    inputs: [
-      { name: "_memecoin", type: "address", internalType: "address" },
-      {
-        name: "_creatorFeeAllocation",
-        type: "uint24",
-        internalType: "uint24",
-      },
-      {
-        name: "_initialMarketCap",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "owner",
-    inputs: [],
-    outputs: [{ name: "result", type: "address", internalType: "address" }],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "ownershipHandoverExpiresAt",
-    inputs: [
-      { name: "pendingOwner", type: "address", internalType: "address" },
-    ],
-    outputs: [{ name: "result", type: "uint256", internalType: "uint256" }],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "removeVerifier",
-    inputs: [{ name: "_verifier", type: "address", internalType: "address" }],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "renounceOwnership",
-    inputs: [],
-    outputs: [],
-    stateMutability: "payable",
-  },
-  {
-    type: "function",
-    name: "requestOwnershipHandover",
-    inputs: [],
-    outputs: [],
-    stateMutability: "payable",
-  },
-  {
-    type: "function",
-    name: "setAnyPositionManager",
-    inputs: [
-      {
-        name: "_anyPositionManager",
-        type: "address",
-        internalType: "address payable",
-      },
-    ],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "transferOwnership",
-    inputs: [{ name: "newOwner", type: "address", internalType: "address" }],
-    outputs: [],
-    stateMutability: "payable",
-  },
-  {
-    type: "function",
-    name: "verifyMemecoin",
-    inputs: [{ name: "_memecoin", type: "address", internalType: "address" }],
-    outputs: [{ name: "verifier_", type: "address", internalType: "address" }],
-    stateMutability: "view",
-  },
-  {
-    type: "event",
-    name: "AnyPositionManagerSet",
-    inputs: [
-      {
-        name: "_anyPositionManager",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "OwnershipHandoverCanceled",
-    inputs: [
-      {
-        name: "pendingOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "OwnershipHandoverRequested",
-    inputs: [
-      {
-        name: "pendingOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "OwnershipTransferred",
-    inputs: [
-      {
-        name: "oldOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "newOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "TokenImported",
-    inputs: [
-      {
-        name: "_memecoin",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "_verifier",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "VerifierAdded",
-    inputs: [
-      {
-        name: "_verifier",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "VerifierRemoved",
-    inputs: [
-      {
-        name: "_verifier",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  { type: "error", name: "AlreadyInitialized", inputs: [] },
-  { type: "error", name: "InvalidMemecoin", inputs: [] },
-  { type: "error", name: "NewOwnerIsZeroAddress", inputs: [] },
-  { type: "error", name: "NoHandoverRequest", inputs: [] },
-  { type: "error", name: "Unauthorized", inputs: [] },
-  { type: "error", name: "VerifierAlreadyAdded", inputs: [] },
-  { type: "error", name: "VerifierNotAdded", inputs: [] },
-  { type: "error", name: "ZeroAddress", inputs: [] },
-] as const;
+    {
+      "type": "constructor",
+      "inputs": [
+        {
+          "name": "_anyPositionManager",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "addVerifier",
+      "inputs": [
+        {
+          "name": "_verifier",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "anyPositionManager",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract AnyPositionManager"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "cancelOwnershipHandover",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "completeOwnershipHandover",
+      "inputs": [
+        {
+          "name": "pendingOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "getAllVerifiers",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "verifiers_",
+          "type": "address[]",
+          "internalType": "address[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "inputs": [
+        {
+          "name": "_memecoin",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "_creatorFeeAllocation",
+          "type": "uint24",
+          "internalType": "uint24"
+        },
+        {
+          "name": "_initialMarketCap",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "_verifier",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "inputs": [
+        {
+          "name": "_memecoin",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "_creatorFeeAllocation",
+          "type": "uint24",
+          "internalType": "uint24"
+        },
+        {
+          "name": "_initialMarketCap",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "_totalSupply",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "_verifier",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "inputs": [
+        {
+          "name": "_memecoin",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "_creatorFeeAllocation",
+          "type": "uint24",
+          "internalType": "uint24"
+        },
+        {
+          "name": "_initialMarketCap",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "owner",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "result",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ownershipHandoverExpiresAt",
+      "inputs": [
+        {
+          "name": "pendingOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "result",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "removeVerifier",
+      "inputs": [
+        {
+          "name": "_verifier",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "renounceOwnership",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "requestOwnershipHandover",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "setAnyPositionManager",
+      "inputs": [
+        {
+          "name": "_anyPositionManager",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferOwnership",
+      "inputs": [
+        {
+          "name": "newOwner",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "verifyMemecoin",
+      "inputs": [
+        {
+          "name": "_memecoin",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "verifier_",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "AnyPositionManagerSet",
+      "inputs": [
+        {
+          "name": "_anyPositionManager",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipHandoverCanceled",
+      "inputs": [
+        {
+          "name": "pendingOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipHandoverRequested",
+      "inputs": [
+        {
+          "name": "pendingOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OwnershipTransferred",
+      "inputs": [
+        {
+          "name": "oldOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "newOwner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TokenImported",
+      "inputs": [
+        {
+          "name": "_memecoin",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "_verifier",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "VerifierAdded",
+      "inputs": [
+        {
+          "name": "_verifier",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "VerifierRemoved",
+      "inputs": [
+        {
+          "name": "_verifier",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "AlreadyInitialized",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidMemecoin",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NewOwnerIsZeroAddress",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NoHandoverRequest",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "Unauthorized",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "VerifierAlreadyAdded",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "VerifierNotAdded",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "ZeroAddress",
+      "inputs": []
+    }
+  ] as const;

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -103,7 +103,7 @@ export const BuyBackManagerAddress: Addresses = {
 
 /** Verifiers */
 export const TokenImporterAddress: Addresses = {
-  [base.id]: "0xb47af90ae61bc916ea4b4bacffae4570e7435842",
+  [base.id]: "0x6fb66f4fc262dc86e12136c481ba7c411e668197",
   [baseSepolia.id]: "0x7981369D21975F39773f289F759F7d7CE1097139",
 };
 

--- a/src/clients/TokenImporter.ts
+++ b/src/clients/TokenImporter.ts
@@ -104,12 +104,14 @@ export class ReadWriteTokenImporter extends ReadTokenImporter {
           creatorFeeAllocationPercent: number;
           initialMarketCapUSD: number;
           verifier?: Verifier;
+          tokenSupply?: bigint;
         }
       | {
           coinAddress: Address;
           creatorFeeAllocationPercent: number;
           initialPriceUSD: number;
           verifier?: Verifier;
+          tokenSupply?: bigint;
         }
   ) {
     return this.contract.write(
@@ -125,12 +127,14 @@ export class ReadWriteTokenImporter extends ReadTokenImporter {
           creatorFeeAllocationPercent: number;
           initialMarketCapUSD: number;
           verifier?: Verifier;
+          tokenSupply?: bigint;
         }
       | {
           coinAddress: Address;
           creatorFeeAllocationPercent: number;
           initialPriceUSD: number;
           verifier?: Verifier;
+          tokenSupply?: bigint;
         }
   ) {
     let initialMarketCapUSD: number;
@@ -157,11 +161,21 @@ export class ReadWriteTokenImporter extends ReadTokenImporter {
           _memecoin: params.coinAddress,
         });
 
-    return {
+    const baseParams = {
       _memecoin: params.coinAddress,
       _creatorFeeAllocation: creatorFeeAllocationInBps,
       _initialMarketCap: initialMCapInUSDCWei,
       _verifier,
     };
+
+    // If tokenSupply is provided (even if 0n), include it to use the 5-parameter initialize overload
+    if (params.tokenSupply !== undefined) {
+      return {
+        ...baseParams,
+        _totalSupply: params.tokenSupply,
+      };
+    }
+
+    return baseParams;
   }
 }

--- a/src/sdk/FlaunchSDK.ts
+++ b/src/sdk/FlaunchSDK.ts
@@ -3401,6 +3401,29 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
 
   /**
    * Gets the calls needed to import a memecoin to Flaunch and single-sided liquidity in coin (from current tick to infinity) to AnyPositionManager as a batch
+   * @param params - Parameters for importing and adding liquidity with initial market cap
+   * @returns Array of calls with descriptions
+   *
+   * @example
+   * ```typescript
+   * const calls = await sdk.getImportAndSingleSidedCoinAddLiquidityCalls({
+   *   coinAddress: "0x...",
+   *   verifier: Verifier.CLANKER,
+   *   creatorFeeAllocationPercent: 5,
+   *   coinAmount: parseEther("1000"),
+   *   initialMarketCapUSD: 50000,
+   *   tokenSupply: 1000000e6 // 1 million tokens (6 decimals)
+   * });
+   * ```
+   */
+  async getImportAndSingleSidedCoinAddLiquidityCalls(
+    params: ImportAndSingleSidedCoinAddLiquidityWithMarketCap & {
+      tokenSupply: bigint;
+    }
+  ): Promise<CallWithDescription[]>;
+
+  /**
+   * Gets the calls needed to import a memecoin to Flaunch and single-sided liquidity in coin (from current tick to infinity) to AnyPositionManager as a batch
    * @param params - Parameters for importing and adding liquidity with initial price
    * @returns Array of calls with descriptions
    *
@@ -3419,6 +3442,29 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
     params: ImportAndSingleSidedCoinAddLiquidityWithPrice
   ): Promise<CallWithDescription[]>;
 
+  /**
+   * Gets the calls needed to import a memecoin to Flaunch and single-sided liquidity in coin (from current tick to infinity) to AnyPositionManager as a batch
+   * @param params - Parameters for importing and adding liquidity with initial price
+   * @returns Array of calls with descriptions
+   *
+   * @example
+   * ```typescript
+   * const calls = await sdk.getImportAndSingleSidedCoinAddLiquidityCalls({
+   *   coinAddress: "0x...",
+   *   verifier: Verifier.CLANKER,
+   *   creatorFeeAllocationPercent: 5,
+   *   coinAmount: parseEther("1000"),
+   *   initialPriceUSD: 0.001,
+   *   tokenSupply: 1000000e6 // 1 million tokens (6 decimals)
+   * });
+   * ```
+   */
+  async getImportAndSingleSidedCoinAddLiquidityCalls(
+    params: ImportAndSingleSidedCoinAddLiquidityWithPrice & {
+      tokenSupply: bigint;
+    }
+  ): Promise<CallWithDescription[]>;
+
   // Implementation with union type for internal use
   async getImportAndSingleSidedCoinAddLiquidityCalls(
     params: ImportAndSingleSidedCoinAddLiquidityParams
@@ -3429,25 +3475,53 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
         params as ImportAndSingleSidedCoinAddLiquidityParams & {
           initialMarketCapUSD: number;
         };
-      importParams = await this.readWriteTokenImporter.getInitializeParams({
-        coinAddress: paramsWithMarketCap.coinAddress,
-        creatorFeeAllocationPercent:
-          paramsWithMarketCap.creatorFeeAllocationPercent,
-        initialMarketCapUSD: paramsWithMarketCap.initialMarketCapUSD,
-        verifier: paramsWithMarketCap.verifier,
-      });
+      if (
+        "tokenSupply" in paramsWithMarketCap &&
+        paramsWithMarketCap.tokenSupply !== undefined
+      ) {
+        importParams = await this.readWriteTokenImporter.getInitializeParams({
+          coinAddress: paramsWithMarketCap.coinAddress,
+          creatorFeeAllocationPercent:
+            paramsWithMarketCap.creatorFeeAllocationPercent,
+          initialMarketCapUSD: paramsWithMarketCap.initialMarketCapUSD,
+          verifier: paramsWithMarketCap.verifier,
+          tokenSupply: paramsWithMarketCap.tokenSupply as bigint,
+        });
+      } else {
+        importParams = await this.readWriteTokenImporter.getInitializeParams({
+          coinAddress: paramsWithMarketCap.coinAddress,
+          creatorFeeAllocationPercent:
+            paramsWithMarketCap.creatorFeeAllocationPercent,
+          initialMarketCapUSD: paramsWithMarketCap.initialMarketCapUSD,
+          verifier: paramsWithMarketCap.verifier,
+        });
+      }
     } else {
       const paramsWithPrice =
         params as ImportAndSingleSidedCoinAddLiquidityParams & {
           initialPriceUSD: number;
         };
-      importParams = await this.readWriteTokenImporter.getInitializeParams({
-        coinAddress: paramsWithPrice.coinAddress,
-        creatorFeeAllocationPercent:
-          paramsWithPrice.creatorFeeAllocationPercent,
-        initialPriceUSD: paramsWithPrice.initialPriceUSD,
-        verifier: paramsWithPrice.verifier,
-      });
+      if (
+        "tokenSupply" in paramsWithPrice &&
+        paramsWithPrice.tokenSupply !== undefined
+      ) {
+        importParams = await this.readWriteTokenImporter.getInitializeParams({
+          coinAddress: paramsWithPrice.coinAddress,
+          creatorFeeAllocationPercent:
+            paramsWithPrice.creatorFeeAllocationPercent,
+          initialPriceUSD: paramsWithPrice.initialPriceUSD,
+          verifier: paramsWithPrice.verifier,
+          tokenSupply: paramsWithPrice.tokenSupply as bigint,
+        });
+      } else {
+        importParams = await this.readWriteTokenImporter.getInitializeParams({
+          coinAddress: paramsWithPrice.coinAddress,
+          creatorFeeAllocationPercent:
+            paramsWithPrice.creatorFeeAllocationPercent,
+          initialPriceUSD: paramsWithPrice.initialPriceUSD,
+          verifier: paramsWithPrice.verifier,
+        });
+      }
     }
 
     const addLiquidityCalls = await this.getSingleSidedCoinAddLiquidityCalls({


### PR DESCRIPTION
This should allow for the `totalSupply` value to be passed into the TokenImporter. The new contract is verified and approved on the AnyPositionManager to call `flaunch`.

This is required as we calculate the market cap based on the USDC <> totalSupply of the token. But when a token is being bridged, we may not have an accurate totalSupply.