### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "dependencies": {
     "@delvtech/drift": "^0.11.0",
     "@delvtech/drift-viem": "^0.11.0",
-    "@uniswap/v3-sdk": "^3.24.1",
+    "@uniswap/v3-sdk": ">=3.24.1 <3.29.0",
     "axios": "^1.8.1",
     "react": "^19.0.0",
     "viem": "^2.29.2"


### PR DESCRIPTION
Superseded by #27, which removed the unused @uniswap/v3-sdk dependency entirely. Current master no longer needs this version constraint; merging it would risk reintroducing the removed dependency. Closed without merging.