### PR TITLE
feat: read and claim creator revenue on the v1.3.1 multi-token FeeEscrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the @flaunch/sdk package will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **v1.3.1 multi-token FeeEscrow support.** Coins paired with anything other than flETH (native ETH, the B20 equities on Base) escrow their creator fees in one multi-token escrow per chain, keyed `(recipient, token)` and denominated in the paired token — a balance the legacy `creatorRevenue()` / `withdrawCreatorRevenue()` path cannot see or claim (its `withdrawFees(address,bool)` selector does not exist on that contract)
+  - `creatorRevenueByToken({ creator, tokens })` returns the claimable balance per escrow token
+  - `withdrawCreatorRevenueByToken({ tokens, recipient?, unwrap? })` sweeps every listed key in one transaction via `withdrawFees(address[],address,bool)`
+  - `ReadFeeEscrowV1_3` / `ReadWriteFeeEscrowV1_3` clients, the `FeeEscrowV1_3Abi`, the `EscrowTokenBalance` type, and `readFeeEscrowV1_3` / `readWriteFeeEscrowV1_3` accessors on the SDK
+  - `doesChainSupportMultiTokenFeeEscrow()` helper, exported from `helpers`
+  - `FeeEscrowV1_3Address` now covers Base Sepolia and Robinhood alongside Base
+
 ## [0.10.0] - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The planned Robinhood UI will route swaps through 0x only; the SDK does not prov
   - [Buying a Flaunch coin](#buying-a-flaunch-coin)
   - [Selling with Permit2](#selling-with-permit2)
   - [Swap using USDC or other tokens by passing `intermediatePoolKey`](#swap-using-usdc-or-other-tokens-by-passing-intermediatepoolkey)
+  - [Claiming creator revenue](#claiming-creator-revenue)
   - [Advanced Integration: Revenue Sharing with RevenueManager](#advanced-integration-revenue-sharing-with-revenuemanager)
   - [Bot Protection during Fair Launch via TrustedSigner](#bot-protection-during-fair-launch-via-trustedsigner)
   - [Groups](#groups)
@@ -477,6 +478,34 @@ if (allowance < parseEther(coinAmount)) {
 ```
 
 3. The quote functions `getSellQuoteExactInput`, `getBuyQuoteExactInput` and `getBuyQuoteExactOutput` also support passing optional `intermediatePoolKey`.
+
+### Claiming creator revenue
+
+Creator fees accrue in a fee escrow and are claimed by the creator (the current holder of the coin's Flaunch NFT). Which escrow depends on the coin's pairing:
+
+- **flETH-paired coins** (the default) use the single-token `FeeEscrow`: `creatorRevenue()` returns the claimable ETH and `withdrawCreatorRevenue()` claims it.
+- **Coins paired with anything else** — native ETH, or a registry token such as the B20 equities on Base (AAPLc, GOOGLc, …) — use the v1.3.1 **multi-token `FeeEscrow`**: one contract per chain, balances keyed `(recipient, token)` and denominated in the paired token. The contract cannot enumerate a recipient's keys, so you name the tokens to look at. A flETH key pays out as ETH; a stock key is delivered as the stock itself.
+
+```ts
+import { zeroAddress } from "viem";
+import { doesChainSupportMultiTokenFeeEscrow } from "@flaunch/sdk";
+
+const AAPLC = "0xb200000000000000000000C2e324d24d7eEcd1fb";
+
+if (doesChainSupportMultiTokenFeeEscrow(base.id)) {
+  // One entry per token, in that token's raw units (AAPLc has 8 decimals)
+  const balances = await flaunchRead.creatorRevenueByToken({
+    creator: creatorAddress,
+    tokens: [zeroAddress, AAPLC],
+  });
+
+  const tokens = balances.filter((b) => b.amount > 0n).map((b) => b.token);
+  if (tokens.length > 0) {
+    // One transaction sweeps every key
+    await flaunchWrite.withdrawCreatorRevenueByToken({ tokens });
+  }
+}
+```
 
 ### Advanced Integration: Revenue Sharing with RevenueManager
 

--- a/src/abi/FeeEscrowV1_3.ts
+++ b/src/abi/FeeEscrowV1_3.ts
@@ -1,0 +1,422 @@
+// Flaunch v1.3.1 multi-token FeeEscrow (one singleton per chain; balances keyed (recipient, token)).
+// Generated from flaunch-contracts `out/FeeEscrow.sol/FeeEscrow.json`.
+export const FeeEscrowV1_3Abi = [
+  {
+    type: "constructor",
+    inputs: [
+      {
+        name: "_pairedTokenRegistry",
+        type: "address",
+        internalType: "address"
+      },
+      {
+        name: "_indexer",
+        type: "address",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "receive",
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "allocateFees",
+    inputs: [
+      {
+        name: "_poolId",
+        type: "bytes32",
+        internalType: "PoolId"
+      },
+      {
+        name: "_token",
+        type: "address",
+        internalType: "address"
+      },
+      {
+        name: "_recipient",
+        type: "address",
+        internalType: "address"
+      },
+      {
+        name: "_amount",
+        type: "uint256",
+        internalType: "uint256"
+      }
+    ],
+    outputs: [],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "balances",
+    inputs: [
+      {
+        name: "_recipient",
+        type: "address",
+        internalType: "address"
+      },
+      {
+        name: "_token",
+        type: "address",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        name: "_amount",
+        type: "uint256",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "cancelOwnershipHandover",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "completeOwnershipHandover",
+    inputs: [
+      {
+        name: "pendingOwner",
+        type: "address",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "indexer",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IIndexerSubscriber"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "owner",
+    inputs: [],
+    outputs: [
+      {
+        name: "result",
+        type: "address",
+        internalType: "address"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "ownershipHandoverExpiresAt",
+    inputs: [
+      {
+        name: "pendingOwner",
+        type: "address",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        name: "result",
+        type: "uint256",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "pairedTokenRegistry",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "address",
+        internalType: "contract IPairedTokenRegistry"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "renounceOwnership",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "requestOwnershipHandover",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "setIndexer",
+    inputs: [
+      {
+        name: "_indexer",
+        type: "address",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "totalFeesAllocated",
+    inputs: [
+      {
+        name: "_poolId",
+        type: "bytes32",
+        internalType: "PoolId"
+      },
+      {
+        name: "_token",
+        type: "address",
+        internalType: "address"
+      }
+    ],
+    outputs: [
+      {
+        name: "_amount",
+        type: "uint256",
+        internalType: "uint256"
+      }
+    ],
+    stateMutability: "view"
+  },
+  {
+    type: "function",
+    name: "transferOwnership",
+    inputs: [
+      {
+        name: "newOwner",
+        type: "address",
+        internalType: "address"
+      }
+    ],
+    outputs: [],
+    stateMutability: "payable"
+  },
+  {
+    type: "function",
+    name: "withdrawFees",
+    inputs: [
+      {
+        name: "_token",
+        type: "address",
+        internalType: "address"
+      },
+      {
+        name: "_recipient",
+        type: "address",
+        internalType: "address"
+      },
+      {
+        name: "_unwrap",
+        type: "bool",
+        internalType: "bool"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "function",
+    name: "withdrawFees",
+    inputs: [
+      {
+        name: "_tokens",
+        type: "address[]",
+        internalType: "address[]"
+      },
+      {
+        name: "_recipient",
+        type: "address",
+        internalType: "address"
+      },
+      {
+        name: "_unwrap",
+        type: "bool",
+        internalType: "bool"
+      }
+    ],
+    outputs: [],
+    stateMutability: "nonpayable"
+  },
+  {
+    type: "event",
+    name: "Deposit",
+    inputs: [
+      {
+        name: "_poolId",
+        type: "bytes32",
+        indexed: true,
+        internalType: "PoolId"
+      },
+      {
+        name: "_payee",
+        type: "address",
+        indexed: false,
+        internalType: "address"
+      },
+      {
+        name: "_token",
+        type: "address",
+        indexed: false,
+        internalType: "address"
+      },
+      {
+        name: "_amount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "OwnershipHandoverCanceled",
+    inputs: [
+      {
+        name: "pendingOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "OwnershipHandoverRequested",
+    inputs: [
+      {
+        name: "pendingOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "OwnershipTransferred",
+    inputs: [
+      {
+        name: "oldOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address"
+      },
+      {
+        name: "newOwner",
+        type: "address",
+        indexed: true,
+        internalType: "address"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "event",
+    name: "Withdrawal",
+    inputs: [
+      {
+        name: "_sender",
+        type: "address",
+        indexed: false,
+        internalType: "address"
+      },
+      {
+        name: "_recipient",
+        type: "address",
+        indexed: false,
+        internalType: "address"
+      },
+      {
+        name: "_token",
+        type: "address",
+        indexed: false,
+        internalType: "address"
+      },
+      {
+        name: "_deliveredAsset",
+        type: "address",
+        indexed: false,
+        internalType: "address"
+      },
+      {
+        name: "_amount",
+        type: "uint256",
+        indexed: false,
+        internalType: "uint256"
+      }
+    ],
+    anonymous: false
+  },
+  {
+    type: "error",
+    name: "AlreadyInitialized",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "IncorrectNativeDeposit",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "IndexerZeroAddress",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "InsufficientNativeValue",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "NewOwnerIsZeroAddress",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "NoHandoverRequest",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "RecipientZeroAddress",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "RegistryZeroAddress",
+    inputs: []
+  },
+  {
+    type: "error",
+    name: "Unauthorized",
+    inputs: []
+  }
+] as const;

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -6,6 +6,7 @@ export * from "./FairLaunch";
 export * from "./FairLaunchV1_1";
 export * from "./FastFlaunchZap";
 export * from "./FeeEscrow";
+export * from "./FeeEscrowV1_3";
 export * from "./Flaunch";
 export * from "./FlaunchPositionManager";
 export * from "./FlaunchPositionManagerV1_0";

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -247,9 +247,13 @@ export const FeeEscrowAddress: Addresses = {
   [robinhood.id]: "0x77A4513CDbE72bBfa8CEE7890D244B66b47f9573",
 };
 
-// v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
+// v1.3.1 (GitHub release v1.3.1) multi-token FeeEscrow: ONE singleton per chain serving every
+// paired token, balances keyed (recipient, token). Base Sepolia runs the same contract from the
+// `.vpt2` deployment (flaunch-contracts deployments/base-sepolia.md); Robinhood from
+// deployments/robinhood-mainnet.md.
 export const FeeEscrowV1_3Address: Addresses = {
   [base.id]: "0x17fbf54d6d15ebff82eee77e616f701952d08bb4",
+  [baseSepolia.id]: "0xf4af7b459e971d9757c2100c626199c6c6334fca",
   [robinhood.id]: "0x4fb9de6bbe970a49c19fb967f937351728c01b8f",
 };
 

--- a/src/clients/FeeEscrowV1_3Client.ts
+++ b/src/clients/FeeEscrowV1_3Client.ts
@@ -1,0 +1,134 @@
+import {
+  type ReadContract,
+  type Address,
+  type Drift,
+  type ReadWriteContract,
+  type ReadWriteAdapter,
+  createDrift,
+} from "@delvtech/drift";
+import { FeeEscrowV1_3Abi } from "../abi/FeeEscrowV1_3";
+
+export type FeeEscrowV1_3ABI = typeof FeeEscrowV1_3Abi;
+
+/** A claimable balance on the multi-token escrow, in the escrow token's own raw units. */
+export interface EscrowTokenBalance {
+  /** The escrow token key — `zeroAddress` for native ETH */
+  token: Address;
+  amount: bigint;
+}
+
+/**
+ * Client for the v1.3.1 multi-token FeeEscrow in read-only mode.
+ *
+ * One escrow per chain serves every paired token — flETH, native ETH (`address(0)`) and the
+ * registry's ERC20 pairings such as the B20 equities. Balances are keyed (recipient, token) and
+ * denominated in that token, so callers name the tokens they are interested in: the contract
+ * cannot enumerate a recipient's keys.
+ */
+export class ReadFeeEscrowV1_3 {
+  public readonly contract: ReadContract<FeeEscrowV1_3ABI>;
+
+  /**
+   * Creates a new ReadFeeEscrowV1_3 instance
+   * @param address - The address of the multi-token FeeEscrow contract
+   * @param drift - Optional drift instance for contract interactions (creates new instance if not provided)
+   * @throws Error if address is not provided
+   */
+  constructor(address: Address, drift: Drift = createDrift()) {
+    if (!address) {
+      throw new Error("Address is required");
+    }
+
+    this.contract = drift.contract({
+      abi: FeeEscrowV1_3Abi,
+      address,
+    });
+  }
+
+  /**
+   * Gets the claimable balance of one escrow token for a recipient
+   * @param recipient - The address of the recipient to check
+   * @param token - The escrow token (`zeroAddress` for native ETH)
+   * @returns Promise<bigint> - The claimable balance in the token's raw units
+   */
+  balances(recipient: Address, token: Address) {
+    return this.contract.read("balances", {
+      _recipient: recipient,
+      _token: token,
+    });
+  }
+
+  /**
+   * Gets the claimable balances across several escrow tokens. Zero balances are kept so callers
+   * can decide what to sweep.
+   * @param recipient - The address of the recipient to check
+   * @param tokens - The escrow tokens to read
+   * @returns Promise<EscrowTokenBalance[]> - One entry per token, in the order given
+   */
+  async balancesForTokens(
+    recipient: Address,
+    tokens: Address[]
+  ): Promise<EscrowTokenBalance[]> {
+    const amounts = await Promise.all(
+      tokens.map((token) => this.balances(recipient, token))
+    );
+    return tokens.map((token, index) => ({ token, amount: amounts[index] }));
+  }
+
+  /**
+   * Gets the total fees a pool has accrued in one escrow token
+   * @param poolId - The pool to check
+   * @param token - The escrow token
+   * @returns Promise<bigint> - The total allocated, in the token's raw units
+   */
+  totalFeesAllocated(poolId: `0x${string}`, token: Address) {
+    return this.contract.read("totalFeesAllocated", {
+      _poolId: poolId,
+      _token: token,
+    });
+  }
+
+  /**
+   * Gets the PairedTokenRegistry that decides each token's unwrap policy on withdrawal
+   * @returns Promise<Address> - The registry address
+   */
+  pairedTokenRegistry() {
+    return this.contract.read("pairedTokenRegistry");
+  }
+}
+
+/**
+ * Extended client for the v1.3.1 multi-token FeeEscrow with write capabilities
+ */
+export class ReadWriteFeeEscrowV1_3 extends ReadFeeEscrowV1_3 {
+  declare contract: ReadWriteContract<FeeEscrowV1_3ABI>;
+
+  constructor(
+    address: Address,
+    drift: Drift<ReadWriteAdapter> = createDrift()
+  ) {
+    super(address, drift);
+  }
+
+  /**
+   * Withdraws the caller's balance in every listed escrow token to a recipient, in one
+   * transaction. A zero-balance or duplicate entry is a harmless no-op on-chain. With `unwrap`
+   * (the default) flETH pays out as ETH and an ERC20 wrapper as its underlying; a plain ERC20
+   * such as a stock is delivered as itself either way.
+   * @param params.tokens - The escrow tokens to withdraw (`zeroAddress` for native ETH)
+   * @param params.recipient - The address to receive the fees
+   * @param params.unwrap - Whether to unwrap wrappers to their underlying asset. Defaults to true
+   * @returns Promise<Hex> - The transaction hash
+   */
+  withdrawFees(params: {
+    tokens: Address[];
+    recipient: Address;
+    unwrap?: boolean;
+  }) {
+    return this.contract.write("withdrawFees", {
+      _tokens: params.tokens,
+      _recipient: params.recipient,
+      _unwrap: params.unwrap ?? true,
+    });
+  }
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,5 +1,9 @@
 export * from "./hex";
 export * from "./ipfs";
 export * from "./chainIdToChain";
-export { isChainSupported, doesChainSupportSplitManager } from "./supportedChains";
+export {
+  isChainSupported,
+  doesChainSupportSplitManager,
+  doesChainSupportMultiTokenFeeEscrow,
+} from "./supportedChains";
 export * from "./permissions";

--- a/src/helpers/supportedChains.ts
+++ b/src/helpers/supportedChains.ts
@@ -4,7 +4,10 @@ import {
   unichain,
 } from "viem/chains";
 import { chainIdToChain } from "./chainIdToChain";
-import { DynamicAddressFeeSplitManagerAddress } from "../addresses";
+import {
+  DynamicAddressFeeSplitManagerAddress,
+  FeeEscrowV1_3Address,
+} from "../addresses";
 
 const multichainDeploymentChainIds = new Set<number>([
   mainnet.id,
@@ -27,4 +30,15 @@ export function isChainSupported(chainId: number): boolean {
  */
 export function doesChainSupportSplitManager(chainId: number): boolean {
   return DynamicAddressFeeSplitManagerAddress[chainId] !== undefined;
+}
+
+/**
+ * Whether the v1.3.1 multi-token FeeEscrow is deployed on the given chain.
+ * Coins launched against a non-flETH pairing (native ETH, the B20 equities)
+ * escrow their creator fees there, keyed (recipient, token) and denominated in
+ * that token; `creatorRevenue()` / `withdrawCreatorRevenue()` only see the
+ * legacy single-token escrow, so gate on this before reading or claiming.
+ */
+export function doesChainSupportMultiTokenFeeEscrow(chainId: number): boolean {
+  return FeeEscrowV1_3Address[chainId] !== undefined;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,11 @@ export type {
   FlaunchWithDynamicSplitManagerParams,
   FlaunchWithDynamicSplitManagerIPFSParams,
 } from "./clients/FlaunchZapClient";
+export {
+  ReadFeeEscrowV1_3,
+  ReadWriteFeeEscrowV1_3,
+} from "./clients/FeeEscrowV1_3Client";
+export type { EscrowTokenBalance } from "./clients/FeeEscrowV1_3Client";
 
 export { ReadFlaunchSDK, ReadWriteFlaunchSDK };
 export { createFlaunch } from "./sdk/factory";

--- a/src/sdk/FlaunchSDK.ts
+++ b/src/sdk/FlaunchSDK.ts
@@ -40,6 +40,7 @@ import {
   AnyBidWallAddress,
   AnyFlaunchAddress,
   FeeEscrowAddress,
+  FeeEscrowV1_3Address,
   ReferralEscrowAddress,
   TokenImporterAddress,
   UniV4PositionManagerAddress,
@@ -112,6 +113,11 @@ import {
   ReadWriteTokenImporter,
 } from "clients/TokenImporter";
 import { ReadFeeEscrow, ReadWriteFeeEscrow } from "clients/FeeEscrowClient";
+import {
+  ReadFeeEscrowV1_3,
+  ReadWriteFeeEscrowV1_3,
+  type EscrowTokenBalance,
+} from "clients/FeeEscrowV1_3Client";
 import {
   ReadReferralEscrow,
   ReadWriteReferralEscrow,
@@ -325,8 +331,22 @@ export class ReadFlaunchSDK {
   private readonly baseClients?: BaseReadClients;
   private readonly swapClients?: SwapReadClients;
   public readonly readFeeEscrow: ReadFeeEscrow;
+  private readonly feeEscrowV1_3?: ReadFeeEscrowV1_3;
 
   public resolveIPFS: (value: string) => string;
+
+  /**
+   * The v1.3.1 multi-token FeeEscrow. Throws on chains without one — gate with
+   * `doesChainSupportMultiTokenFeeEscrow()`.
+   */
+  get readFeeEscrowV1_3(): ReadFeeEscrowV1_3 {
+    if (!this.feeEscrowV1_3) {
+      throw new Error(
+        `Multi-token FeeEscrow is not supported on chain ${this.chainId}`
+      );
+    }
+    return this.feeEscrowV1_3;
+  }
 
   private getBaseClient<K extends keyof BaseReadClients>(
     name: K
@@ -453,6 +473,10 @@ export class ReadFlaunchSDK {
       FeeEscrowAddress[this.chainId],
       drift
     );
+    const feeEscrowV1_3Address = FeeEscrowV1_3Address[this.chainId];
+    if (feeEscrowV1_3Address) {
+      this.feeEscrowV1_3 = new ReadFeeEscrowV1_3(feeEscrowV1_3Address, drift);
+    }
 
     const quoterAddress = QuoterAddress[this.chainId];
     const permit2Address = Permit2Address[this.chainId];
@@ -1523,6 +1547,25 @@ export class ReadFlaunchSDK {
   }
 
   /**
+   * Gets the creator's claimable revenue on the v1.3.1 multi-token FeeEscrow, per escrow token.
+   * Coins paired with anything other than flETH (native ETH, the B20 equities, …) escrow their
+   * creator fees there, denominated in the paired token, where `creatorRevenue()` cannot see
+   * them. The escrow cannot enumerate a recipient's keys, so pass the paired tokens to look at.
+   * @param params.creator - The address of the creator to check
+   * @param params.tokens - The escrow tokens to read (`zeroAddress` for native ETH)
+   * @returns The claimable amount per token, in that token's raw units (zero balances included)
+   */
+  creatorRevenueByToken(params: {
+    creator: Address;
+    tokens: Address[];
+  }): Promise<EscrowTokenBalance[]> {
+    return this.readFeeEscrowV1_3.balancesForTokens(
+      params.creator,
+      params.tokens
+    );
+  }
+
+  /**
    * Gets the balance of a recipient for a given coin
    * @param recipient - The address of the recipient to check
    * @param coinAddress - The address of the coin
@@ -2490,6 +2533,20 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
   private readonly baseReadWriteClients?: BaseReadWriteClients;
   private readonly readWriteFlaunchZapMultichain?: ReadWriteFlaunchZapMultichain;
   public readonly readWriteFeeEscrow: ReadWriteFeeEscrow;
+  private readonly readWriteFeeEscrowV1_3Client?: ReadWriteFeeEscrowV1_3;
+
+  /**
+   * The v1.3.1 multi-token FeeEscrow with write capabilities. Throws on chains without one —
+   * gate with `doesChainSupportMultiTokenFeeEscrow()`.
+   */
+  get readWriteFeeEscrowV1_3(): ReadWriteFeeEscrowV1_3 {
+    if (!this.readWriteFeeEscrowV1_3Client) {
+      throw new Error(
+        `Multi-token FeeEscrow is not supported on chain ${this.chainId}`
+      );
+    }
+    return this.readWriteFeeEscrowV1_3Client;
+  }
 
   private getBaseReadWriteClient<K extends keyof BaseReadWriteClients>(
     name: K
@@ -2538,6 +2595,13 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
       FeeEscrowAddress[this.chainId],
       drift
     );
+    const feeEscrowV1_3Address = FeeEscrowV1_3Address[this.chainId];
+    if (feeEscrowV1_3Address) {
+      this.readWriteFeeEscrowV1_3Client = new ReadWriteFeeEscrowV1_3(
+        feeEscrowV1_3Address,
+        drift
+      );
+    }
 
     if (isMultichainDeployment(this.chainId)) {
       this.readWriteFlaunchZapMultichain = new ReadWriteFlaunchZapMultichain(
@@ -3010,6 +3074,30 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
 
     const recipient = params.recipient ?? (await this.drift.getSignerAddress());
     return this.readWriteFeeEscrow.withdrawFees(recipient);
+  }
+
+  /**
+   * Withdraws the creator's revenue from the v1.3.1 multi-token FeeEscrow across the given
+   * escrow tokens, in one transaction. Pass every token with a balance from
+   * `creatorRevenueByToken()`; a zero balance is a harmless no-op. flETH pays out as ETH while
+   * `unwrap` is left on; a stock pairing is delivered as the stock itself either way.
+   * @param params - Parameters for withdrawing the creator's revenue
+   * @param params.tokens - The escrow tokens to withdraw (`zeroAddress` for native ETH)
+   * @param params.recipient - The address to withdraw the revenue to. Defaults to the connected wallet
+   * @param params.unwrap - Whether to unwrap wrappers to their underlying asset. Defaults to true
+   * @returns Transaction response
+   */
+  async withdrawCreatorRevenueByToken(params: {
+    tokens: Address[];
+    recipient?: Address;
+    unwrap?: boolean;
+  }) {
+    const recipient = params.recipient ?? (await this.drift.getSignerAddress());
+    return this.readWriteFeeEscrowV1_3.withdrawFees({
+      tokens: params.tokens,
+      recipient,
+      unwrap: params.unwrap,
+    });
   }
 
   /**

--- a/test/feeEscrowV1_3.test.cjs
+++ b/test/feeEscrowV1_3.test.cjs
@@ -1,0 +1,136 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  createPublicClient,
+  custom,
+  decodeFunctionData,
+  encodeAbiParameters,
+  parseAbi,
+  toHex,
+  zeroAddress,
+} = require("viem");
+const { base, mainnet } = require("viem/chains");
+const {
+  createFlaunchCalldata,
+  decodeCallData,
+  doesChainSupportMultiTokenFeeEscrow,
+  FeeEscrowV1_3Abi,
+  FeeEscrowV1_3Address,
+} = require("../dist/index.cjs.js");
+
+const CREATOR = "0xD2FfD38191e6B4DF807DF3F13536D1cdBE8d059e";
+const AAPLC = "0xb200000000000000000000C2e324d24d7eEcd1fb";
+const ESCROW = FeeEscrowV1_3Address[base.id];
+/** balances(address,address) */
+const BALANCES_SELECTOR = "0xc23f001f";
+/** withdrawFees(address[],address,bool) */
+const BATCH_WITHDRAW_SELECTOR = "0x82525ad1";
+
+/** Drift batches concurrent reads through Multicall3; answer each inner call the same way. */
+const MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11";
+const aggregate3Abi = parseAbi([
+  "function aggregate3((address target, bool allowFailure, bytes callData)[] calls) view returns ((bool success, bytes returnData)[] returnData)",
+]);
+
+function answerReads(call, calls, encodedResult) {
+  if (call.to.toLowerCase() === MULTICALL3.toLowerCase()) {
+    const [inner] = decodeFunctionData({ abi: aggregate3Abi, data: call.data }).args;
+    for (const { target, callData } of inner) calls.push({ to: target, data: callData });
+    return encodeAbiParameters(aggregate3Abi[0].outputs, [
+      inner.map(() => ({ success: true, returnData: encodedResult })),
+    ]);
+  }
+  calls.push(call);
+  return encodedResult;
+}
+
+function publicClientFor(chain, onCall) {
+  return createPublicClient({
+    chain,
+    transport: custom({
+      async request({ method, params }) {
+        if (method === "eth_chainId") return toHex(chain.id);
+        if (method === "eth_call") return onCall(params[0]);
+        throw new Error(`Unexpected RPC request: ${method}`);
+      },
+    }),
+  });
+}
+
+test("withdrawCreatorRevenueByToken encodes the batch withdrawFees on the v1.3.1 escrow", async () => {
+  const sdk = createFlaunchCalldata({
+    publicClient: publicClientFor(base, () => "0x"),
+    walletAddress: CREATOR,
+  });
+
+  const encoded = await sdk.withdrawCreatorRevenueByToken({
+    tokens: [AAPLC, zeroAddress],
+  });
+  const transaction = decodeCallData(encoded);
+
+  assert.equal(transaction.to.toLowerCase(), ESCROW.toLowerCase());
+  assert.equal(transaction.value, 0n);
+  assert.equal(transaction.data.slice(0, 10), BATCH_WITHDRAW_SELECTOR);
+  const decoded = decodeFunctionData({
+    abi: FeeEscrowV1_3Abi,
+    data: transaction.data,
+  });
+  assert.equal(decoded.functionName, "withdrawFees");
+  // recipient defaults to the connected wallet; unwrap defaults on
+  assert.deepEqual(decoded.args, [[AAPLC, zeroAddress], CREATOR, true]);
+});
+
+test("withdrawCreatorRevenueByToken honours an explicit recipient and unwrap=false", async () => {
+  const RECIPIENT = "0x1111111111111111111111111111111111111111";
+  const sdk = createFlaunchCalldata({
+    publicClient: publicClientFor(base, () => "0x"),
+    walletAddress: CREATOR,
+  });
+
+  const encoded = await sdk.withdrawCreatorRevenueByToken({
+    tokens: [AAPLC],
+    recipient: RECIPIENT,
+    unwrap: false,
+  });
+  const decoded = decodeFunctionData({
+    abi: FeeEscrowV1_3Abi,
+    data: decodeCallData(encoded).data,
+  });
+
+  assert.deepEqual(decoded.args, [[AAPLC], RECIPIENT, false]);
+});
+
+test("creatorRevenueByToken reads balances(recipient, token) per escrow token", async () => {
+  const calls = [];
+  const publicClient = publicClientFor(base, (call) =>
+    answerReads(call, calls, encodeAbiParameters([{ type: "uint256" }], [110000678n]))
+  );
+  const sdk = createFlaunchCalldata({ publicClient, walletAddress: CREATOR });
+
+  const balances = await sdk.creatorRevenueByToken({
+    creator: CREATOR,
+    tokens: [AAPLC, zeroAddress],
+  });
+
+  assert.deepEqual(balances, [
+    { token: AAPLC, amount: 110000678n },
+    { token: zeroAddress, amount: 110000678n },
+  ]);
+  assert.equal(calls.length, 2);
+  assert.ok(calls.every((call) => call.to.toLowerCase() === ESCROW.toLowerCase()));
+  assert.ok(calls.every((call) => call.data.slice(0, 10) === BALANCES_SELECTOR));
+});
+
+test("chains without the multi-token escrow say so before anything is sent", async () => {
+  assert.equal(doesChainSupportMultiTokenFeeEscrow(base.id), true);
+  assert.equal(doesChainSupportMultiTokenFeeEscrow(mainnet.id), false);
+
+  const sdk = createFlaunchCalldata({
+    publicClient: publicClientFor(mainnet, () => "0x"),
+    walletAddress: CREATOR,
+  });
+  await assert.rejects(
+    () => sdk.withdrawCreatorRevenueByToken({ tokens: [zeroAddress] }),
+    /Multi-token FeeEscrow is not supported on chain 1/
+  );
+});


### PR DESCRIPTION
## Why

Coins paired with anything other than flETH — native ETH, or a registry token such as the B20 equities on Base (AAPLc, GOOGLc, METAc, NVDAc) — escrow their creator fees in the v1.3.1 **multi-token `FeeEscrow`**: one singleton per chain (`0x17fbF54d…` on Base), balances keyed `(recipient, token)` and denominated in the paired token. The SDK's `creatorRevenue()` / `withdrawCreatorRevenue()` only talk to the legacy single-token escrow, and the legacy `withdrawFees(address,bool)` selector does not exist on the new contract, so an integrator had no way to show or claim those fees. `FeeEscrowV1_3Address` was exported in 0.10.0 but nothing used it.

This is what let a creator's ~$341 of AAPLc fees sit invisible in the Flaunch app (frontend fix: flayerlabs/reflaunch — linked below; API fix: flayerlabs/reflaunch-backend#178).

## What

- `src/abi/FeeEscrowV1_3.ts` — generated from the compiled `FeeEscrow.sol` artifact in flaunch-contracts (`balances(address,address)`, `withdrawFees(address,address,bool)`, `withdrawFees(address[],address,bool)`, `totalFeesAllocated(bytes32,address)`, `pairedTokenRegistry()`, the 5-param `Withdrawal` event …).
- `ReadFeeEscrowV1_3` / `ReadWriteFeeEscrowV1_3` clients: `balances(recipient, token)`, `balancesForTokens(recipient, tokens)`, `totalFeesAllocated`, `pairedTokenRegistry`, `withdrawFees({ tokens, recipient, unwrap })`.
- SDK: `creatorRevenueByToken({ creator, tokens })` → `EscrowTokenBalance[]` (raw units per token; the escrow cannot enumerate keys, so callers name the tokens); `withdrawCreatorRevenueByToken({ tokens, recipient?, unwrap? })` → one batch `withdrawFees(address[],address,bool)` sweep (`0x82525ad1`); `readFeeEscrowV1_3` / `readWriteFeeEscrowV1_3` accessors that throw a clear error on chains without the escrow.
- `doesChainSupportMultiTokenFeeEscrow()` helper; `FeeEscrowV1_3Address` extended with Base Sepolia (`0xF4AF7b45…`, the `.vpt2` deployment) and Robinhood (`0x4Fb9dE6b…`).
- README "Claiming creator revenue" section, CHANGELOG under `[Unreleased]`. No version bump — release commits are separate here; `llms-full.txt` / typedoc left for release time.

## Verification

- `pnpm typecheck` clean; `pnpm test` (build + node test runner) green, incl. new `test/feeEscrowV1_3.test.cjs`: the batch selector and decoded args (default recipient + unwrap, explicit recipient + `unwrap=false`), per-token `balances` reads through Drift's Multicall3 batching, and the unsupported-chain guard.
- The same calldata shape was executed end-to-end on an anvil fork of Base for a native-ETH key (status `0x1`, `Withdrawal` event, exact wei credited). Stock keys cannot be simulated on a fork — the B20 tokens are a single-byte `0xef` precompile REVM cannot run (flaunch-contracts `deployments/base-mainnet.md` §7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)