### PR TITLE
release: @flaunch/sdk 0.11.1 — Robinhood v1.3.1 manager generation, rebound zap, TokenImporterV1_3Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the @flaunch/sdk package will be documented in this file.
 
+## [0.11.1] - 2026-09-02
+
+### Added
+
+- **v1.3.1 multi-asset managers on Robinhood Chain (4663)** — flaunch-managers' `v1.3.1-base` generation deployed on 2026-09-02 (FLA2-388): `TreasuryManagerFactoryV1_3Address`, `RevenueManagerV1_3Address`, `AddressFeeSplitManagerV1_3Address`, `DynamicAddressFeeSplitManagerV1_3Address`, `ERC721OwnerFeeSplitManagerV1_3Address`, `StakingManagerV1_3Address`, `GroupMapperV1_3Address`, `FlaunchManagerZapV1_3Address` and `WhitelistedPermissionsV1_3Address` gain a `robinhood` row, so `doesChainSupportMultiAssetManagers(4663)` is now `true` and every `*V1_3` manager method works there
+- `TokenImporterV1_3Address` — the v1.3.1 `TokenImporter` on Base (`0xea78c266…`) and Robinhood (`0x08222EA6…`). The unsuffixed `TokenImporterAddress` keeps pointing at the previous generation's importer
+
+### Changed
+
+- `FlaunchZapV1_3Address[robinhood]` → `0xFCd1eB4BFA9A97059CaF4D160d28C871F5f3077a`, the zap redeployed on 2026-09-02 bound to the new Robinhood factory. The factory-less `0x2e744436…` it replaces routes a manager launch into the manager implementation and strands the launch NFT; `flaunchPairedToken()` and `doesChainSupportPairedTokenLaunch()` now target the bound zap
+
 ## [0.11.0] - 2026-08-26
 
 ### Added

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1272,7 +1272,7 @@ For detailed protocol documentation, visit our [Docs](https://docs.flaunch.gg/).
 
 # API Documentation
 
-@flaunch/sdk - v0.11.0 / Exports / FlaunchBackend
+@flaunch/sdk - v0.11.1 / Exports / FlaunchBackend
 
 # Class: FlaunchBackend
 
@@ -1380,7 +1380,7 @@ src/sdk/FlaunchBackend.ts:119
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadDynamicAddressFeeSplitManager
+@flaunch/sdk - v0.11.1 / Exports / ReadDynamicAddressFeeSplitManager
 
 # Class: ReadDynamicAddressFeeSplitManager
 
@@ -1691,7 +1691,7 @@ src/clients/DynamicAddressFeeSplitManagerClient.ts:62
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadDynamicAddressFeeSplitManagerV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadDynamicAddressFeeSplitManagerV1\_3
 
 # Class: ReadDynamicAddressFeeSplitManagerV1\_3
 
@@ -2088,7 +2088,7 @@ src/clients/DynamicAddressFeeSplitManagerV1_3Client.ts:67
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadFeeEscrowV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadFeeEscrowV1\_3
 
 # Class: ReadFeeEscrowV1\_3
 
@@ -2244,7 +2244,7 @@ src/clients/FeeEscrowV1_3Client.ts:84
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadFlaunchManagerZapV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadFlaunchManagerZapV1\_3
 
 # Class: ReadFlaunchManagerZapV1\_3
 
@@ -2336,7 +2336,7 @@ src/clients/FlaunchManagerZapV1_3Client.ts:69
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadFlaunchSDK
+@flaunch/sdk - v0.11.1 / Exports / ReadFlaunchSDK
 
 # Class: ReadFlaunchSDK
 
@@ -4691,7 +4691,7 @@ src/sdk/FlaunchSDK.ts:1243
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadFlaunchZapV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadFlaunchZapV1\_3
 
 # Class: ReadFlaunchZapV1\_3
 
@@ -4763,7 +4763,7 @@ src/clients/FlaunchZapV1_3Client.ts:55
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadPairedTokenRegistryV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadPairedTokenRegistryV1\_3
 
 # Class: ReadPairedTokenRegistryV1\_3
 
@@ -4829,7 +4829,7 @@ src/clients/PairedTokenRegistryV1_3Client.ts:26
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadRevenueManagerV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadRevenueManagerV1\_3
 
 # Class: ReadRevenueManagerV1\_3
 
@@ -5164,7 +5164,7 @@ src/clients/RevenueManagerV1_3Client.ts:194
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadStakingManagerV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadStakingManagerV1\_3
 
 # Class: ReadStakingManagerV1\_3
 
@@ -5579,7 +5579,7 @@ src/clients/StakingManagerV1_3Client.ts:100
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadTreasuryManagerV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadTreasuryManagerV1\_3
 
 # Class: ReadTreasuryManagerV1\_3
 
@@ -5850,7 +5850,7 @@ src/clients/TreasuryManagerV1_3Client.ts:147
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteDynamicAddressFeeSplitManager
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteDynamicAddressFeeSplitManager
 
 # Class: ReadWriteDynamicAddressFeeSplitManager
 
@@ -6425,7 +6425,7 @@ src/clients/DynamicAddressFeeSplitManagerClient.ts:168
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteDynamicAddressFeeSplitManagerV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteDynamicAddressFeeSplitManagerV1\_3
 
 # Class: ReadWriteDynamicAddressFeeSplitManagerV1\_3
 
@@ -7165,7 +7165,7 @@ src/clients/DynamicAddressFeeSplitManagerV1_3Client.ts:295
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteFeeEscrowV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteFeeEscrowV1\_3
 
 # Class: ReadWriteFeeEscrowV1\_3
 
@@ -7363,7 +7363,7 @@ src/clients/FeeEscrowV1_3Client.ts:123
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteFlaunchManagerZapV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteFlaunchManagerZapV1\_3
 
 # Class: ReadWriteFlaunchManagerZapV1\_3
 
@@ -7533,7 +7533,7 @@ src/clients/FlaunchManagerZapV1_3Client.ts:69
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteFlaunchSDK
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteFlaunchSDK
 
 # Class: ReadWriteFlaunchSDK
 
@@ -11681,7 +11681,7 @@ src/sdk/FlaunchSDK.ts:3409
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteFlaunchZapV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteFlaunchZapV1\_3
 
 # Class: ReadWriteFlaunchZapV1\_3
 
@@ -11784,7 +11784,7 @@ src/clients/FlaunchZapV1_3Client.ts:84
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteRevenueManagerV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteRevenueManagerV1\_3
 
 # Class: ReadWriteRevenueManagerV1\_3
 
@@ -12356,7 +12356,7 @@ src/clients/RevenueManagerV1_3Client.ts:259
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteStakingManagerV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteStakingManagerV1\_3
 
 # Class: ReadWriteStakingManagerV1\_3
 
@@ -13128,7 +13128,7 @@ src/clients/StakingManagerV1_3Client.ts:281
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / ReadWriteTreasuryManagerV1\_3
+@flaunch/sdk - v0.11.1 / Exports / ReadWriteTreasuryManagerV1\_3
 
 # Class: ReadWriteTreasuryManagerV1\_3
 
@@ -13601,7 +13601,7 @@ src/clients/TreasuryManagerV1_3Client.ts:147
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / FlaunchVersion
+@flaunch/sdk - v0.11.1 / Exports / FlaunchVersion
 
 # Enumeration: FlaunchVersion
 
@@ -13660,7 +13660,7 @@ src/types.ts:55
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / LiquidityMode
+@flaunch/sdk - v0.11.1 / Exports / LiquidityMode
 
 # Enumeration: LiquidityMode
 
@@ -13690,7 +13690,7 @@ src/types.ts:72
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / Permissions
+@flaunch/sdk - v0.11.1 / Exports / Permissions
 
 # Enumeration: Permissions
 
@@ -13731,7 +13731,7 @@ src/types.ts:85
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / Verifier
+@flaunch/sdk - v0.11.1 / Exports / Verifier
 
 # Enumeration: Verifier
 
@@ -13799,7 +13799,7 @@ src/types.ts:68
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / Addresses
+@flaunch/sdk - v0.11.1 / Exports / Addresses
 
 # Interface: Addresses
 
@@ -13810,7 +13810,7 @@ src/types.ts:68
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / AssetBalance
+@flaunch/sdk - v0.11.1 / Exports / AssetBalance
 
 # Interface: AssetBalance
 
@@ -13844,7 +13844,7 @@ src/clients/TreasuryManagerV1_3Client.ts:19
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / BuySwapData
+@flaunch/sdk - v0.11.1 / Exports / BuySwapData
 
 # Interface: BuySwapData
 
@@ -13882,7 +13882,7 @@ src/utils/parseSwap.ts:22
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / CallData
+@flaunch/sdk - v0.11.1 / Exports / CallData
 
 # Interface: CallData
 
@@ -13921,7 +13921,7 @@ src/sdk/calldata.ts:22
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / CoinMetadata
+@flaunch/sdk - v0.11.1 / Exports / CoinMetadata
 
 # Interface: CoinMetadata
 
@@ -14005,7 +14005,7 @@ src/types.ts:32
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / DeployManagerV1\_3Params
+@flaunch/sdk - v0.11.1 / Exports / DeployManagerV1\_3Params
 
 # Interface: DeployManagerV1\_3Params
 
@@ -14061,7 +14061,7 @@ src/clients/FlaunchManagerZapV1_3Client.ts:33
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / EscrowTokenBalance
+@flaunch/sdk - v0.11.1 / Exports / EscrowTokenBalance
 
 # Interface: EscrowTokenBalance
 
@@ -14095,7 +14095,7 @@ src/clients/FeeEscrowV1_3Client.ts:16
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / FlaunchWithDynamicSplitManagerIPFSParams
+@flaunch/sdk - v0.11.1 / Exports / FlaunchWithDynamicSplitManagerIPFSParams
 
 # Interface: FlaunchWithDynamicSplitManagerIPFSParams
 
@@ -14369,7 +14369,7 @@ src/clients/FlaunchZapClient.ts:52
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / FlaunchWithDynamicSplitManagerParams
+@flaunch/sdk - v0.11.1 / Exports / FlaunchWithDynamicSplitManagerParams
 
 # Interface: FlaunchWithDynamicSplitManagerParams
 
@@ -14597,7 +14597,7 @@ src/clients/FlaunchZapClient.ts:52
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / IPFSParams
+@flaunch/sdk - v0.11.1 / Exports / IPFSParams
 
 # Interface: IPFSParams
 
@@ -14644,7 +14644,7 @@ src/types.ts:45
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / PinataConfig
+@flaunch/sdk - v0.11.1 / Exports / PinataConfig
 
 # Interface: PinataConfig
 
@@ -14665,7 +14665,7 @@ src/helpers/ipfs.ts:27
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / PoolKey
+@flaunch/sdk - v0.11.1 / Exports / PoolKey
 
 # Interface: PoolKey
 
@@ -14728,7 +14728,7 @@ src/types.ts:17
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / PoolWithHookData
+@flaunch/sdk - v0.11.1 / Exports / PoolWithHookData
 
 # Interface: PoolWithHookData
 
@@ -14820,7 +14820,7 @@ src/types.ts:17
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / SellSwapData
+@flaunch/sdk - v0.11.1 / Exports / SellSwapData
 
 # Interface: SellSwapData
 
@@ -14858,7 +14858,7 @@ src/utils/parseSwap.ts:31
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / SingleSidedLiquidityInfo
+@flaunch/sdk - v0.11.1 / Exports / SingleSidedLiquidityInfo
 
 # Interface: SingleSidedLiquidityInfo
 
@@ -14897,7 +14897,7 @@ src/types.ts:198
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / SwapFees
+@flaunch/sdk - v0.11.1 / Exports / SwapFees
 
 # Interface: SwapFees
 
@@ -14927,7 +14927,7 @@ src/utils/parseSwap.ts:17
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports / SwapLogArgs
+@flaunch/sdk - v0.11.1 / Exports / SwapLogArgs
 
 # Interface: SwapLogArgs
 
@@ -15047,9 +15047,9 @@ src/utils/parseSwap.ts:13
 
 ---
 
-@flaunch/sdk - v0.11.0 / Exports
+@flaunch/sdk - v0.11.1 / Exports
 
-# @flaunch/sdk - v0.11.0
+# @flaunch/sdk - v0.11.1
 
 ## Table of contents
 
@@ -15204,6 +15204,7 @@ src/utils/parseSwap.ts:13
 - TICK\_SPACING
 - TickFinder
 - TokenImporterAddress
+- TokenImporterV1\_3Address
 - TreasuryManagerFactoryAddress
 - TreasuryManagerFactoryV1\_3Address
 - USDCETHPoolKeys
@@ -15719,7 +15720,7 @@ ___
 
 • `Const` **AddressFeeSplitManagerV1\_3Address**: `Addresses`
 
-src/addresses.ts:217
+src/addresses.ts:220
 
 ___
 
@@ -15807,7 +15808,7 @@ ___
 
 • `Const` **ClankerWorldVerifierAddress**: `Addresses`
 
-src/addresses.ts:249
+src/addresses.ts:266
 
 ___
 
@@ -15817,7 +15818,7 @@ ___
 
 Permissions
 
-src/addresses.ts:282
+src/addresses.ts:299
 
 ___
 
@@ -15825,7 +15826,7 @@ ___
 
 • `Const` **DopplerVerifierAddress**: `Addresses`
 
-src/addresses.ts:254
+src/addresses.ts:271
 
 ___
 
@@ -15841,7 +15842,7 @@ ___
 
 • `Const` **DynamicAddressFeeSplitManagerV1\_3Address**: `Addresses`
 
-src/addresses.ts:221
+src/addresses.ts:225
 
 ___
 
@@ -15849,7 +15850,7 @@ ___
 
 • `Const` **ERC721OwnerFeeSplitManagerV1\_3Address**: `Addresses`
 
-src/addresses.ts:225
+src/addresses.ts:230
 
 ___
 
@@ -15857,7 +15858,7 @@ ___
 
 • `Const` **FLETHAddress**: `Addresses`
 
-src/addresses.ts:335
+src/addresses.ts:353
 
 ___
 
@@ -15865,7 +15866,7 @@ ___
 
 • `Const` **FLETHHooksAddress**: `Addresses`
 
-src/addresses.ts:404
+src/addresses.ts:422
 
 ___
 
@@ -15889,7 +15890,7 @@ ___
 
 • `Const` **FastFlaunchZapAddress**: `Addresses`
 
-src/addresses.ts:411
+src/addresses.ts:429
 
 ___
 
@@ -15899,7 +15900,7 @@ ___
 
 ===========
 
-src/addresses.ts:306
+src/addresses.ts:324
 
 ___
 
@@ -15907,7 +15908,7 @@ ___
 
 • `Const` **FeeEscrowV1\_3Address**: `Addresses`
 
-src/addresses.ts:318
+src/addresses.ts:336
 
 ___
 
@@ -15923,7 +15924,7 @@ ___
 
 • `Const` **FlaunchManagerZapV1\_3Address**: `Addresses`
 
-src/addresses.ts:239
+src/addresses.ts:247
 
 ___
 
@@ -16042,7 +16043,7 @@ ___
 
 • `Const` **GroupMapperV1\_3Address**: `Addresses`
 
-src/addresses.ts:233
+src/addresses.ts:240
 
 ___
 
@@ -16089,7 +16090,7 @@ ___
 
 • `Const` **Permit2Address**: `Addresses`
 
-src/addresses.ts:444
+src/addresses.ts:462
 
 ___
 
@@ -16097,7 +16098,7 @@ ___
 
 • `Const` **PoolManagerAddress**: `Addresses`
 
-src/addresses.ts:416
+src/addresses.ts:434
 
 ___
 
@@ -16121,7 +16122,7 @@ ___
 
 • `Const` **QuoterAddress**: `Addresses`
 
-src/addresses.ts:430
+src/addresses.ts:448
 
 ___
 
@@ -16129,7 +16130,7 @@ ___
 
 • `Const` **ReferralEscrowAddress**: `Addresses`
 
-src/addresses.ts:324
+src/addresses.ts:342
 
 ___
 
@@ -16137,7 +16138,7 @@ ___
 
 • `Const` **ReferralEscrowV1\_3Address**: `Addresses`
 
-src/addresses.ts:330
+src/addresses.ts:348
 
 ___
 
@@ -16153,7 +16154,7 @@ ___
 
 • `Const` **RevenueManagerV1\_3Address**: `Addresses`
 
-src/addresses.ts:213
+src/addresses.ts:215
 
 ___
 
@@ -16161,7 +16162,7 @@ ___
 
 • `Const` **SolanaVerifierAddress**: `Addresses`
 
-src/addresses.ts:259
+src/addresses.ts:276
 
 ___
 
@@ -16177,7 +16178,7 @@ ___
 
 • `Const` **StakingManagerV1\_3Address**: `Addresses`
 
-src/addresses.ts:229
+src/addresses.ts:235
 
 ___
 
@@ -16185,7 +16186,7 @@ ___
 
 • `Const` **StateViewAddress**: `Addresses`
 
-src/addresses.ts:436
+src/addresses.ts:454
 
 ___
 
@@ -16218,7 +16219,15 @@ ___
 
 Verifiers
 
-src/addresses.ts:244
+src/addresses.ts:253
+
+___
+
+### TokenImporterV1\_3Address
+
+• `Const` **TokenImporterV1\_3Address**: `Addresses`
+
+src/addresses.ts:261
 
 ___
 
@@ -16234,7 +16243,7 @@ ___
 
 • `Const` **TreasuryManagerFactoryV1\_3Address**: `Addresses`
 
-src/addresses.ts:209
+src/addresses.ts:210
 
 ___
 
@@ -16246,7 +16255,7 @@ Index signature
 
 ▪ [chainId: `number`]: `PoolKey`
 
-src/addresses.ts:455
+src/addresses.ts:473
 
 ___
 
@@ -16254,7 +16263,7 @@ ___
 
 • `Const` **UniV4PositionManagerAddress**: `Addresses`
 
-src/addresses.ts:450
+src/addresses.ts:468
 
 ___
 
@@ -16262,7 +16271,7 @@ ___
 
 • `Const` **UniversalRouterAddress**: `Addresses`
 
-src/addresses.ts:424
+src/addresses.ts:442
 
 ___
 
@@ -16270,7 +16279,7 @@ ___
 
 • `Const` **VirtualsVerifierAddress**: `Addresses`
 
-src/addresses.ts:264
+src/addresses.ts:281
 
 ___
 
@@ -16278,7 +16287,7 @@ ___
 
 • `Const` **WhitelistVerifierAddress**: `Addresses`
 
-src/addresses.ts:269
+src/addresses.ts:286
 
 ___
 
@@ -16286,7 +16295,7 @@ ___
 
 • `Const` **WhitelistedPermissionsAddress**: `Addresses`
 
-src/addresses.ts:290
+src/addresses.ts:307
 
 ___
 
@@ -16294,7 +16303,7 @@ ___
 
 • `Const` **WhitelistedPermissionsV1\_3Address**: `Addresses`
 
-src/addresses.ts:301
+src/addresses.ts:318
 
 ___
 
@@ -16302,7 +16311,7 @@ ___
 
 • `Const` **ZoraVerifierAddress**: `Addresses`
 
-src/addresses.ts:274
+src/addresses.ts:291
 
 ___
 
@@ -16601,7 +16610,7 @@ ___
 
 Whether the v1.3.1 multi-asset manager generation (its own TreasuryManagerFactory,
 manager implementations and FlaunchManagerZap) is deployed on the given chain — Base
-mainnet only today. Managers from this generation pay out per payout asset (ETH or the
+mainnet and Robinhood Chain today. Managers from this generation pay out per payout asset (ETH or the
 coin's paired token) and are driven through the `*V1_3` manager APIs; the unsuffixed
 manager APIs keep talking to the previous generation. Gate on this before deploying,
 reading or claiming from a v1.3.1 manager.
@@ -16658,7 +16667,7 @@ Returns
 
 `boolean`
 
-src/addresses.ts:386
+src/addresses.ts:404
 
 ___
 
@@ -16718,7 +16727,7 @@ Returns
 
 `boolean`
 
-src/addresses.ts:396
+src/addresses.ts:414
 
 ___
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaunch/sdk",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Flaunch SDK to easily interact with the Flaunch protocol",
   "license": "MIT",
   "author": "Apoorv Lathey <apoorv@flayer.io>",

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -13,15 +13,15 @@ export const FlaunchZapAddress: Addresses = {
   [baseSepolia.id]: "0x25b747aeca2612b9804b5c3bb272a3daefdc6eaa",
 };
 
-// v1.3.1 (GitHub release v1.3.1) paired-token FlaunchZap deployments.
-// Base: redeployed 2026-08-27 bound to the v1.3.1 TreasuryManagerFactory (replaces
-// 0x29b37dfe…, which had no factory and could strand a launch NFT inside a manager
-// implementation). Robinhood's v1.3.1 zap is still factory-less — the same hazard applies there,
-// so do not route manager launches through it until it is rebound (FLA2-388).
+// v1.3.1 (GitHub release v1.3.1) paired-token FlaunchZap deployments, each bound to its chain's
+// v1.3.1 TreasuryManagerFactory. Base: redeployed 2026-08-27 (replaces 0x29b37dfe…). Robinhood:
+// redeployed 2026-09-02 (FLA2-388; replaces 0x2e744436…). The replaced zaps had no factory and
+// route a manager launch into the manager IMPLEMENTATION, stranding the launch NFT — never point
+// a manager launch back at them. Base Sepolia's zap is still factory-less.
 export const FlaunchZapV1_3Address: Addresses = {
   [base.id]: "0xf787d757674b21efd713fb636b16ed994bfa82a8",
   [baseSepolia.id]: "0xe8476aa6508f0c31e3126f2340d18e9c6fbf8dd3",
-  [robinhood.id]: "0x2e744436e35bc346777288b8dae2da23fd67e542",
+  [robinhood.id]: "0xFCd1eB4BFA9A97059CaF4D160d28C871F5f3077a",
 };
 
 export const FlaunchZapMultichainAddress: Addresses = {
@@ -202,48 +202,65 @@ export const BuyBackManagerAddress: Addresses = {
   [baseSepolia.id]: "0xc3947EC9d687053bBA72b36Fd6b2567e775E82C7",
 };
 
-// v1.3.1 multi-asset managers (flaunch-managers release v1.3.1-base) - Base mainnet only
+// v1.3.1 multi-asset managers (flaunch-managers release v1.3.1-base): Base mainnet (2026-08-25)
+// and Robinhood Chain (2026-09-02, FLA2-388).
 // A separate generation from the *ManagerAddress maps above: its own factory, implementations
 // and zap, paying out per payout asset (ETH = address(0), or the coin's paired token). Managers
 // deployed from the old factory keep working through the unsuffixed APIs.
 export const TreasuryManagerFactoryV1_3Address: Addresses = {
   [base.id]: "0xB03Be6c735ef90189D6a22bBC8F6A45a33348fDe",
+  [robinhood.id]: "0xE1eBcD62AEBd327A4c22dB9e68A8E81119a7eABF",
 };
 
 export const RevenueManagerV1_3Address: Addresses = {
   [base.id]: "0x908D692E628073A5B644Bc32B8dF57A5d1842288",
+  [robinhood.id]: "0xFc28B339376018727eFcD45fdb257D0A0861A391",
 };
 
 export const AddressFeeSplitManagerV1_3Address: Addresses = {
   [base.id]: "0x7dC776cf57DacA91b315fe4F8803577dAb560ba5",
+  [robinhood.id]: "0x7dc0f14204841e0314eB0265a0c420995F200243",
 };
 
 export const DynamicAddressFeeSplitManagerV1_3Address: Addresses = {
   [base.id]: "0xC4a0B79A0dB1F7F67da97E7F9A8867B6CaF017b2",
+  [robinhood.id]: "0x1969bcF2779D53FeEA95480a7ab79f7cEfeE1681",
 };
 
 export const ERC721OwnerFeeSplitManagerV1_3Address: Addresses = {
   [base.id]: "0xDbFA9d3cab72EAE6Ba44ebC27175706aA451d9c0",
+  [robinhood.id]: "0x51BdE7C1e2Ea54949C015F4f3ED3CAE185543C0b",
 };
 
 export const StakingManagerV1_3Address: Addresses = {
   [base.id]: "0x72b9192017361eA00cDc1Cf1AC0F178cf89920cA",
+  [robinhood.id]: "0xd992F465d55B005E8D2Aff9fcE977Cb78f5652e0",
 };
 
 export const GroupMapperV1_3Address: Addresses = {
   [base.id]: "0x4a68638179De37163d86B10e6B4b927CA1a0dE87",
+  [robinhood.id]: "0xBdbF379f9EdFB5993FC00b41AAEfeE8475eAC0Ac",
 };
 
 // Deploys + initializes a v1.3.1 manager through the v1.3.1 factory in one call. Launching a coin
 // straight into a manager stays with the core FlaunchZap.
 export const FlaunchManagerZapV1_3Address: Addresses = {
   [base.id]: "0xD7E0c1D2B2a588cEC3b2Bdc9428FfE59b739749B",
+  [robinhood.id]: "0xAf037090FF86EFdc8d4ba82728aC93042ad1EC73",
 };
 
 /** Verifiers */
 export const TokenImporterAddress: Addresses = {
   [base.id]: "0x6fb66f4fc262dc86e12136c481ba7c411e668197",
   [baseSepolia.id]: "0x7981369D21975F39773f289F759F7d7CE1097139",
+};
+
+// v1.3.1 (GitHub release v1.3.1) TokenImporter per chain. The unsuffixed map above is the
+// previous generation's importer (Base's 0x6fb66f4f… is being retired) and is left untouched for
+// callers importing into the old hooks.
+export const TokenImporterV1_3Address: Addresses = {
+  [base.id]: "0xea78c26690b5a0dde2a5a8db7760b5da79bfd76e",
+  [robinhood.id]: "0x08222EA6aBe9111b77cf006Dc7F0a7c71fcCF390",
 };
 
 export const ClankerWorldVerifierAddress: Addresses = {
@@ -295,11 +312,12 @@ export const WhitelistedPermissionsAddress: Addresses = {
   [baseSepolia.id]: "0xe8691E8f576A98c41EBB5E984207d4F51386621f",
 };
 
-// v1.3.1 multi-asset managers (flaunch-managers release v1.3.1-base) - Base mainnet only
+// v1.3.1 multi-asset managers (flaunch-managers release v1.3.1-base) — Base and Robinhood.
 // WhitelistedPermissions validates a group against the factory it was built with, so managers
 // from the v1.3.1 factory need this instance. ClosedPermissions is factory-agnostic and reused.
 export const WhitelistedPermissionsV1_3Address: Addresses = {
   [base.id]: "0xaCE028CB08A19C4d2a6e442516EbA7d114C09Af9",
+  [robinhood.id]: "0xF772256B811D2241488d3d659E9cf797B387eFC3",
 };
 /** =========== */
 

--- a/src/helpers/supportedChains.ts
+++ b/src/helpers/supportedChains.ts
@@ -51,7 +51,7 @@ export function doesChainSupportMultiTokenFeeEscrow(chainId: number): boolean {
 /**
  * Whether the v1.3.1 multi-asset manager generation (its own TreasuryManagerFactory,
  * manager implementations and FlaunchManagerZap) is deployed on the given chain — Base
- * mainnet only today. Managers from this generation pay out per payout asset (ETH or the
+ * mainnet and Robinhood Chain today. Managers from this generation pay out per payout asset (ETH or the
  * coin's paired token) and are driven through the `*V1_3` manager APIs; the unsuffixed
  * manager APIs keep talking to the previous generation. Gate on this before deploying,
  * reading or claiming from a v1.3.1 manager.

--- a/test/managersV1_3.test.cjs
+++ b/test/managersV1_3.test.cjs
@@ -12,7 +12,7 @@ const {
   toHex,
   zeroAddress,
 } = require("viem");
-const { base, baseSepolia, mainnet } = require("viem/chains");
+const { base, robinhood, baseSepolia, mainnet } = require("viem/chains");
 const {
   createFlaunchCalldata,
   decodeCallData,
@@ -61,16 +61,17 @@ const PAYOUT_ASSETS_SELECTOR = "0x27b72e39";
 const PROTOCOL_RECIPIENT_SELECTOR = toFunctionSelector("protocolRecipient()");
 
 /** The flaunch-managers `v1.3.1-base` release (Base mainnet, blocks 50439728–50439746). */
+// [map, Base address, Robinhood address] — Robinhood rows landed with FLA2-388 (2026-09-02).
 const RELEASE_ADDRESSES = {
-  TreasuryManagerFactoryV1_3Address: [TreasuryManagerFactoryV1_3Address, "0xB03Be6c735ef90189D6a22bBC8F6A45a33348fDe"],
-  RevenueManagerV1_3Address: [RevenueManagerV1_3Address, "0x908D692E628073A5B644Bc32B8dF57A5d1842288"],
-  AddressFeeSplitManagerV1_3Address: [AddressFeeSplitManagerV1_3Address, "0x7dC776cf57DacA91b315fe4F8803577dAb560ba5"],
-  DynamicAddressFeeSplitManagerV1_3Address: [DynamicAddressFeeSplitManagerV1_3Address, "0xC4a0B79A0dB1F7F67da97E7F9A8867B6CaF017b2"],
-  ERC721OwnerFeeSplitManagerV1_3Address: [ERC721OwnerFeeSplitManagerV1_3Address, "0xDbFA9d3cab72EAE6Ba44ebC27175706aA451d9c0"],
-  StakingManagerV1_3Address: [StakingManagerV1_3Address, "0x72b9192017361eA00cDc1Cf1AC0F178cf89920cA"],
-  GroupMapperV1_3Address: [GroupMapperV1_3Address, "0x4a68638179De37163d86B10e6B4b927CA1a0dE87"],
-  FlaunchManagerZapV1_3Address: [FlaunchManagerZapV1_3Address, "0xD7E0c1D2B2a588cEC3b2Bdc9428FfE59b739749B"],
-  WhitelistedPermissionsV1_3Address: [WhitelistedPermissionsV1_3Address, "0xaCE028CB08A19C4d2a6e442516EbA7d114C09Af9"],
+  TreasuryManagerFactoryV1_3Address: [TreasuryManagerFactoryV1_3Address, "0xB03Be6c735ef90189D6a22bBC8F6A45a33348fDe", "0xE1eBcD62AEBd327A4c22dB9e68A8E81119a7eABF"],
+  RevenueManagerV1_3Address: [RevenueManagerV1_3Address, "0x908D692E628073A5B644Bc32B8dF57A5d1842288", "0xFc28B339376018727eFcD45fdb257D0A0861A391"],
+  AddressFeeSplitManagerV1_3Address: [AddressFeeSplitManagerV1_3Address, "0x7dC776cf57DacA91b315fe4F8803577dAb560ba5", "0x7dc0f14204841e0314eB0265a0c420995F200243"],
+  DynamicAddressFeeSplitManagerV1_3Address: [DynamicAddressFeeSplitManagerV1_3Address, "0xC4a0B79A0dB1F7F67da97E7F9A8867B6CaF017b2", "0x1969bcF2779D53FeEA95480a7ab79f7cEfeE1681"],
+  ERC721OwnerFeeSplitManagerV1_3Address: [ERC721OwnerFeeSplitManagerV1_3Address, "0xDbFA9d3cab72EAE6Ba44ebC27175706aA451d9c0", "0x51BdE7C1e2Ea54949C015F4f3ED3CAE185543C0b"],
+  StakingManagerV1_3Address: [StakingManagerV1_3Address, "0x72b9192017361eA00cDc1Cf1AC0F178cf89920cA", "0xd992F465d55B005E8D2Aff9fcE977Cb78f5652e0"],
+  GroupMapperV1_3Address: [GroupMapperV1_3Address, "0x4a68638179De37163d86B10e6B4b927CA1a0dE87", "0xBdbF379f9EdFB5993FC00b41AAEfeE8475eAC0Ac"],
+  FlaunchManagerZapV1_3Address: [FlaunchManagerZapV1_3Address, "0xD7E0c1D2B2a588cEC3b2Bdc9428FfE59b739749B", "0xAf037090FF86EFdc8d4ba82728aC93042ad1EC73"],
+  WhitelistedPermissionsV1_3Address: [WhitelistedPermissionsV1_3Address, "0xaCE028CB08A19C4d2a6e442516EbA7d114C09Af9", "0xF772256B811D2241488d3d659E9cf797B387eFC3"],
 };
 
 /** Drift batches concurrent reads through Multicall3; answer each inner call on its own. */
@@ -132,15 +133,19 @@ function decodeBalancesArgs(call) {
   return decodeFunctionData({ abi: TreasuryManagerV1_3Abi, data: call.data }).args;
 }
 
-test("the v1.3.1 manager generation is pinned to the Base release and absent elsewhere", () => {
-  for (const [name, [map, expected]] of Object.entries(RELEASE_ADDRESSES)) {
-    assert.deepEqual(Object.keys(map), [String(base.id)], `${name} should be Base-only`);
-    assert.equal(getAddress(map[base.id]), getAddress(expected), name);
+test("the v1.3.1 manager generation is pinned to the Base and Robinhood releases and absent elsewhere", () => {
+  for (const [name, [map, expectedBase, expectedRobinhood]] of Object.entries(RELEASE_ADDRESSES)) {
+    assert.deepEqual(Object.keys(map).sort(), [String(robinhood.id), String(base.id)].sort(), `${name} should be Base + Robinhood only`);
+    assert.equal(getAddress(map[base.id]), getAddress(expectedBase), name);
+    assert.equal(getAddress(map[robinhood.id]), getAddress(expectedRobinhood), name);
   }
   // ClosedPermissions is factory-agnostic and reused by the new generation
   assert.equal(getAddress(ClosedPermissionsAddress[base.id]), "0x4dfc76A31A2a0110739611683a8b6C5201480fa1");
-  // the redeployed core zap, bound to the v1.3.1 factory (replaces 0x29b37dfe…)
+  assert.equal(getAddress(ClosedPermissionsAddress[robinhood.id]), "0xF0469beF728c498f3621008C65B95EDa56C82Ae3");
+  // the redeployed core zaps, bound to each chain's v1.3.1 factory (replace 0x29b37dfe… / 0x2e744436…)
   assert.equal(getAddress(FlaunchZapV1_3Address[base.id]), "0xf787d757674b21efD713fB636B16ed994bfa82A8");
+  assert.equal(getAddress(FlaunchZapV1_3Address[robinhood.id]), "0xFCd1eB4BFA9A97059CaF4D160d28C871F5f3077a");
+  assert.equal(doesChainSupportMultiAssetManagers(robinhood.id), true);
 
   assert.equal(doesChainSupportMultiAssetManagers(base.id), true);
   assert.equal(doesChainSupportMultiAssetManagers(baseSepolia.id), false);


### PR DESCRIPTION
## Summary
- Robinhood (4663) rows for every `*V1_3Address` manager map (factory `0xE1eBcD62…`, RevenueManager `0xFc28B339…`, FlaunchManagerZap `0xAf037090…`, WhitelistedPermissions `0xF772256B…`, …) from the 2026-09-02 FLA2-388 deployment, so `doesChainSupportMultiAssetManagers(4663)` is true.
- `FlaunchZapV1_3Address[robinhood]` → `0xFCd1eB4BFA9A97059CaF4D160d28C871F5f3077a`, the zap rebound to that factory. The factory-less `0x2e744436…` routes a manager launch into the manager implementation and strands the NFT.
- New `TokenImporterV1_3Address` (Base `0xea78c266…`, Robinhood `0x08222EA6…`); the unsuffixed map keeps the previous generation.
- CHANGELOG 0.11.1, version bump, manager test extended to both chains.

## Test plan
- [x] `pnpm test` — 46/46
- [ ] after merge: tag `@flaunch/sdk@0.11.1`, `pnpm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)