### PR TITLE
release: @flaunch/sdk 0.11.2 — Robinhood v1.3.3 hook regeneration, SupersededPositionManagerV1_3Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the @flaunch/sdk package will be documented in this file.
 
+## [0.11.2] - UNRELEASED (prepared 2026-09-02)
+
+### Changed
+
+- **Robinhood v1.3.3 hook regeneration.** The 2026-08-21 v1.3.1 hooks on Robinhood were wired to a pre-#285 `InternalSwapPool`; the generation was regenerated onto a fresh, fixed ISP with the SAME `PairedTokenRegistry`, multi-token `FeeEscrow`, `TreasuryManagerFactory` and managers. The 4663 rows of `FlaunchPositionManagerV1_3Address`, `PairedTokenPositionManagerV1_3Address`, `AnyPositionManagerV1_3Address`, `FlaunchV1_3Address`, `AnyFlaunchV1_3Address`, `BidWallV1_3Address`, `AnyBidWallV1_3Address`, `FlaunchZapV1_3Address`, `TokenImporterV1_3Address` and `ReferralEscrowV1_3Address` now point at the v1.3.3 contracts. Registry, escrow, factory, manager, flETH and PoolSwap rows are unchanged. (Addresses marked PREDICTED in `src/addresses.ts` are confirmed against the broadcast before publish.)
+
+### Added
+
+- `SupersededPositionManagerV1_3Address: Record<chainId, Address[]>` — hooks a chain's v1.3 generation moved off but that still serve the pools launched on them (Robinhood: `0x588c683e…`, `0x6ea0edee…`). Coins never migrate, so anything resolving "which hook is this coin on" must consult these alongside the current maps.
+- `getV1_3PositionManagers(chainId)` (helpers) — current + superseded v1.3 hooks in one list.
+- `getPoolCreatedFromLogs()` accepts `PoolCreated` from any current or superseded v1.3 hook on the chain.
+
 ## [0.11.1] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the @flaunch/sdk package will be documented in this file.
 
 ### Changed
 
-- **Robinhood v1.3.3 hook regeneration.** The 2026-08-21 v1.3.1 hooks on Robinhood were wired to a pre-#285 `InternalSwapPool`; the generation was regenerated onto a fresh, fixed ISP with the SAME `PairedTokenRegistry`, multi-token `FeeEscrow`, `TreasuryManagerFactory` and managers. The 4663 rows of `FlaunchPositionManagerV1_3Address`, `PairedTokenPositionManagerV1_3Address`, `AnyPositionManagerV1_3Address`, `FlaunchV1_3Address`, `AnyFlaunchV1_3Address`, `BidWallV1_3Address`, `AnyBidWallV1_3Address`, `FlaunchZapV1_3Address`, `TokenImporterV1_3Address` and `ReferralEscrowV1_3Address` now point at the v1.3.3 contracts. Registry, escrow, factory, manager, flETH and PoolSwap rows are unchanged. (Addresses marked PREDICTED in `src/addresses.ts` are confirmed against the broadcast before publish.)
+- **Robinhood v1.3.3 hook regeneration.** The 2026-08-21 v1.3.1 hooks on Robinhood were wired to a pre-#285 `InternalSwapPool`; the generation was regenerated onto a fresh, fixed ISP with the SAME `PairedTokenRegistry`, multi-token `FeeEscrow`, `TreasuryManagerFactory` and managers. The 4663 rows of `FlaunchPositionManagerV1_3Address`, `PairedTokenPositionManagerV1_3Address`, `AnyPositionManagerV1_3Address`, `FlaunchV1_3Address`, `AnyFlaunchV1_3Address`, `BidWallV1_3Address`, `AnyBidWallV1_3Address`, `FlaunchZapV1_3Address`, `TokenImporterV1_3Address` and `ReferralEscrowV1_3Address` now point at the v1.3.3 contracts. Registry, escrow, factory, manager, flETH and PoolSwap rows are unchanged. Confirmed against the live broadcast (Robinhood blocks 53313466–53315211, 2026-09-03).
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaunch/sdk",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Flaunch SDK to easily interact with the Flaunch protocol",
   "license": "MIT",
   "author": "Apoorv Lathey <apoorv@flayer.io>",

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -21,7 +21,7 @@ export const FlaunchZapAddress: Addresses = {
 export const FlaunchZapV1_3Address: Addresses = {
   [base.id]: "0xf787d757674b21efd713fb636b16ed994bfa82a8",
   [baseSepolia.id]: "0xe8476aa6508f0c31e3126f2340d18e9c6fbf8dd3",
-  [robinhood.id]: "0x740f8278Fd9C548fF50b64805337eA8Ad24b2553", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0x740f8278Fd9C548fF50b64805337eA8Ad24b2553",
 };
 
 export const FlaunchZapMultichainAddress: Addresses = {
@@ -63,7 +63,7 @@ export const FlaunchPositionManagerV1_2Address: Addresses = {
 // superseded v1.3.1 hooks still serve their pools — see SupersededPositionManagerV1_3Address.
 export const FlaunchPositionManagerV1_3Address: Addresses = {
   [base.id]: "0x588c683ecc450f8b2aadb13d7f63792b840425dc",
-  [robinhood.id]: "0x8D346f24278C5CD786309161aAC0fC2bbe4c25dc", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0x8D346f24278C5CD786309161aAC0fC2bbe4c25dc",
 };
 
 /**
@@ -84,7 +84,7 @@ export const SupersededPositionManagerV1_3Address: Record<number, Address[]> = {
 export const PairedTokenPositionManagerV1_3Address: Addresses = {
   [base.id]: "0x588c683ecc450f8b2aadb13d7f63792b840425dc",
   [baseSepolia.id]: "0x5558e7271ec2e8b2faaf05f0eedab1cd986be5dc",
-  [robinhood.id]: "0x8D346f24278C5CD786309161aAC0fC2bbe4c25dc", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0x8D346f24278C5CD786309161aAC0fC2bbe4c25dc",
 };
 
 export const PairedTokenRegistryV1_3Address: Addresses = {
@@ -101,7 +101,7 @@ export const AnyPositionManagerAddress: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyPositionManagerV1_3Address: Addresses = {
   [base.id]: "0x6ea0edee449a287504990df8d87951b9436825dc",
-  [robinhood.id]: "0x9AbfbDc34A294De5210C0889f21D5Af54C4965DC", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0x9AbfbDc34A294De5210C0889f21D5Af54C4965DC",
 };
 
 export const FlaunchAddress: Addresses = {
@@ -122,7 +122,7 @@ export const FlaunchV1_2Address: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const FlaunchV1_3Address: Addresses = {
   [base.id]: "0x475a09618bfd00fa4cb03b8504e95b62075e6f7d",
-  [robinhood.id]: "0x373c037C90a681079c3343ddAFCEEa8d9D8DE96E", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0x373c037C90a681079c3343ddAFCEEa8d9D8DE96E",
 };
 
 export const AnyFlaunchAddress: Addresses = {
@@ -133,7 +133,7 @@ export const AnyFlaunchAddress: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyFlaunchV1_3Address: Addresses = {
   [base.id]: "0x299c7e6992a4630d77a8cbd60aa78e17189e53f7",
-  [robinhood.id]: "0x1bbbD15A6D5176edc7B42f2cc6cA800D9d74015D", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0x1bbbD15A6D5176edc7B42f2cc6cA800D9d74015D",
 };
 
 export const FairLaunchAddress: Addresses = {
@@ -161,7 +161,7 @@ export const BidWallV1_1Address: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const BidWallV1_3Address: Addresses = {
   [base.id]: "0x0dae90b70f62ce3b1d5278f4763bd1f595d6a687",
-  [robinhood.id]: "0xB95ad380B6C2F39b67d8582Eb198ba3881Aa06D4", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0xB95ad380B6C2F39b67d8582Eb198ba3881Aa06D4",
 };
 
 export const AnyBidWallAddress: Addresses = {
@@ -172,7 +172,7 @@ export const AnyBidWallAddress: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyBidWallV1_3Address: Addresses = {
   [base.id]: "0x9d58ca8011096ad711babf0d990c45b9d5bb047d",
-  [robinhood.id]: "0xf32316145caf0A381FA587A7CE1bf850d58Af3aC", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0xf32316145caf0A381FA587A7CE1bf850d58Af3aC",
 };
 
 export const TreasuryManagerFactoryAddress: Addresses = {
@@ -275,7 +275,7 @@ export const TokenImporterAddress: Addresses = {
 // callers importing into the old hooks.
 export const TokenImporterV1_3Address: Addresses = {
   [base.id]: "0xea78c26690b5a0dde2a5a8db7760b5da79bfd76e",
-  [robinhood.id]: "0xf7579C3cb8607F6CE00311465d28Ac45666f39Ad", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0xf7579C3cb8607F6CE00311465d28Ac45666f39Ad",
 };
 
 export const ClankerWorldVerifierAddress: Addresses = {
@@ -362,7 +362,7 @@ export const ReferralEscrowAddress: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const ReferralEscrowV1_3Address: Addresses = {
   [base.id]: "0xe86bfebc4f094d36074833618779d279a9af01aa",
-  [robinhood.id]: "0xB9827C0c7Cb61be4D58700B114E34D8448889eD8", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+  [robinhood.id]: "0xB9827C0c7Cb61be4D58700B114E34D8448889eD8",
 };
 
 export const FLETHAddress: Addresses = {

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -13,11 +13,12 @@ export const FlaunchZapAddress: Addresses = {
   [baseSepolia.id]: "0x25b747aeca2612b9804b5c3bb272a3daefdc6eaa",
 };
 
-// v1.3.1 (GitHub release v1.3.1) paired-token FlaunchZap deployments, each bound to its chain's
-// v1.3.1 TreasuryManagerFactory. Base: redeployed 2026-08-27 (replaces 0x29b37dfe…). Robinhood:
-// redeployed 2026-09-02 (FLA2-388; replaces 0x2e744436…). The replaced zaps had no factory and
-// route a manager launch into the manager IMPLEMENTATION, stranding the launch NFT — never point
-// a manager launch back at them. Base Sepolia's zap is still factory-less.
+// v1.3.x paired-token FlaunchZap deployments, each bound to its chain's v1.3.1
+// TreasuryManagerFactory. Base: redeployed 2026-08-27 (replaces the factory-less 0x29b37dfe…).
+// Robinhood: the v1.3.3 regeneration's zap, deployed bound in-run 2026-09-03 (supersedes the
+// 09-02 rebind 0xFCd1eB4B… and the factory-less 0x2e744436…). Factory-less zaps route a manager
+// launch into the manager IMPLEMENTATION, stranding the launch NFT — never point a manager launch
+// at one. Base Sepolia's zap is still factory-less.
 export const FlaunchZapV1_3Address: Addresses = {
   [base.id]: "0xf787d757674b21efd713fb636b16ed994bfa82a8",
   [baseSepolia.id]: "0xe8476aa6508f0c31e3126f2340d18e9c6fbf8dd3",

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -21,7 +21,7 @@ export const FlaunchZapAddress: Addresses = {
 export const FlaunchZapV1_3Address: Addresses = {
   [base.id]: "0xf787d757674b21efd713fb636b16ed994bfa82a8",
   [baseSepolia.id]: "0xe8476aa6508f0c31e3126f2340d18e9c6fbf8dd3",
-  [robinhood.id]: "0xFCd1eB4BFA9A97059CaF4D160d28C871F5f3077a",
+  [robinhood.id]: "0x740f8278Fd9C548fF50b64805337eA8Ad24b2553", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const FlaunchZapMultichainAddress: Addresses = {
@@ -58,10 +58,25 @@ export const FlaunchPositionManagerV1_2Address: Addresses = {
   [baseSepolia.id]: "0x4e7cb1e6800a7b297b38bddcecaf9ca5b6616fdc",
 };
 
-// v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
+// v1.3.x paired-token hooks. Base: v1.3.1 (2026-08-20). Robinhood: the v1.3.3 regeneration
+// (fresh post-#285 InternalSwapPool; same registry / escrow / factory as v1.3.1). Robinhood's
+// superseded v1.3.1 hooks still serve their pools — see SupersededPositionManagerV1_3Address.
 export const FlaunchPositionManagerV1_3Address: Addresses = {
   [base.id]: "0x588c683ecc450f8b2aadb13d7f63792b840425dc",
-  [robinhood.id]: "0x588c683ecc450f8b2aadb13d7f63792b840425dc", // CREATE3 — same address as Base
+  [robinhood.id]: "0x8D346f24278C5CD786309161aAC0fC2bbe4c25dc", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
+};
+
+/**
+ * Hooks that a chain's v1.3 generation has moved OFF but that still serve the pools launched on
+ * them (coins never migrate). Consumers resolving "which hook is this coin on" must consult
+ * these alongside the current maps. Robinhood 2026-08-21 -> 2026-09-xx: the v1.3.1 hooks were
+ * regenerated onto a fixed InternalSwapPool (v1.3.3).
+ */
+export const SupersededPositionManagerV1_3Address: Record<number, Address[]> = {
+  [robinhood.id]: [
+    "0x588c683ecc450f8b2aadb13d7f63792b840425dc", // v1.3.1 PositionManager (CREATE3, shared with Base)
+    "0x6ea0edee449a287504990df8d87951b9436825dc", // v1.3.1 AnyPositionManager
+  ],
 };
 
 // PositionManagers used by the paired-token launch path. This is separate from
@@ -69,7 +84,7 @@ export const FlaunchPositionManagerV1_3Address: Addresses = {
 export const PairedTokenPositionManagerV1_3Address: Addresses = {
   [base.id]: "0x588c683ecc450f8b2aadb13d7f63792b840425dc",
   [baseSepolia.id]: "0x5558e7271ec2e8b2faaf05f0eedab1cd986be5dc",
-  [robinhood.id]: "0x588c683ecc450f8b2aadb13d7f63792b840425dc", // CREATE3 — same address as Base
+  [robinhood.id]: "0x8D346f24278C5CD786309161aAC0fC2bbe4c25dc", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const PairedTokenRegistryV1_3Address: Addresses = {
@@ -86,7 +101,7 @@ export const AnyPositionManagerAddress: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyPositionManagerV1_3Address: Addresses = {
   [base.id]: "0x6ea0edee449a287504990df8d87951b9436825dc",
-  [robinhood.id]: "0x6ea0edee449a287504990df8d87951b9436825dc", // CREATE3 — same address as Base
+  [robinhood.id]: "0x9AbfbDc34A294De5210C0889f21D5Af54C4965DC", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const FlaunchAddress: Addresses = {
@@ -107,7 +122,7 @@ export const FlaunchV1_2Address: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const FlaunchV1_3Address: Addresses = {
   [base.id]: "0x475a09618bfd00fa4cb03b8504e95b62075e6f7d",
-  [robinhood.id]: "0x929d4815fe415b85e53975aec58a8980bda3d90c",
+  [robinhood.id]: "0x373c037C90a681079c3343ddAFCEEa8d9D8DE96E", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const AnyFlaunchAddress: Addresses = {
@@ -118,7 +133,7 @@ export const AnyFlaunchAddress: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyFlaunchV1_3Address: Addresses = {
   [base.id]: "0x299c7e6992a4630d77a8cbd60aa78e17189e53f7",
-  [robinhood.id]: "0x33f04d3a76cffa25e5da285d97336e67611b2282",
+  [robinhood.id]: "0x1bbbD15A6D5176edc7B42f2cc6cA800D9d74015D", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const FairLaunchAddress: Addresses = {
@@ -146,7 +161,7 @@ export const BidWallV1_1Address: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const BidWallV1_3Address: Addresses = {
   [base.id]: "0x0dae90b70f62ce3b1d5278f4763bd1f595d6a687",
-  [robinhood.id]: "0x641d5cf4290c7c6e45cb672c4467a9e4fc89d72d",
+  [robinhood.id]: "0xB95ad380B6C2F39b67d8582Eb198ba3881Aa06D4", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const AnyBidWallAddress: Addresses = {
@@ -157,7 +172,7 @@ export const AnyBidWallAddress: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyBidWallV1_3Address: Addresses = {
   [base.id]: "0x9d58ca8011096ad711babf0d990c45b9d5bb047d",
-  [robinhood.id]: "0x361a874945c07069beed611f950506a8e324b630",
+  [robinhood.id]: "0xf32316145caf0A381FA587A7CE1bf850d58Af3aC", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const TreasuryManagerFactoryAddress: Addresses = {
@@ -260,7 +275,7 @@ export const TokenImporterAddress: Addresses = {
 // callers importing into the old hooks.
 export const TokenImporterV1_3Address: Addresses = {
   [base.id]: "0xea78c26690b5a0dde2a5a8db7760b5da79bfd76e",
-  [robinhood.id]: "0x08222EA6aBe9111b77cf006Dc7F0a7c71fcCF390",
+  [robinhood.id]: "0xf7579C3cb8607F6CE00311465d28Ac45666f39Ad", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const ClankerWorldVerifierAddress: Addresses = {
@@ -347,7 +362,7 @@ export const ReferralEscrowAddress: Addresses = {
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const ReferralEscrowV1_3Address: Addresses = {
   [base.id]: "0xe86bfebc4f094d36074833618779d279a9af01aa",
-  [robinhood.id]: "0xb6c0cca8b3a354fa0f348c121657f4a952e92b3d",
+  [robinhood.id]: "0xB9827C0c7Cb61be4D58700B114E34D8448889eD8", // v1.3.3 PREDICTED (fork rehearsal 2026-09-02) — confirm from broadcast/FreshChainV2.s.sol/4663/run-latest.json
 };
 
 export const FLETHAddress: Addresses = {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -6,6 +6,7 @@ export {
   doesChainSupportSplitManager,
   doesChainSupportMultiTokenFeeEscrow,
   doesChainSupportMultiAssetManagers,
+  getV1_3PositionManagers,
   doesChainSupportPairedTokenLaunch,
 } from "./supportedChains";
 export * from "./permissions";

--- a/src/helpers/supportedChains.ts
+++ b/src/helpers/supportedChains.ts
@@ -1,3 +1,4 @@
+import type { Address } from "viem";
 import {
   mainnet,
   robinhood,
@@ -12,6 +13,7 @@ import {
   FlaunchZapV1_3Address,
   PairedTokenPositionManagerV1_3Address,
   PairedTokenRegistryV1_3Address,
+  SupersededPositionManagerV1_3Address,
 } from "../addresses";
 
 const multichainDeploymentChainIds = new Set<number>([
@@ -70,4 +72,17 @@ export function doesChainSupportPairedTokenLaunch(chainId: number): boolean {
     PairedTokenPositionManagerV1_3Address[chainId] !== undefined &&
     PairedTokenRegistryV1_3Address[chainId] !== undefined
   );
+}
+
+/**
+ * Every v1.3 hook that has ever been the paired-token PositionManager on a chain: the current
+ * one plus any superseded generations that still serve their pools. Use this when deciding
+ * whether an arbitrary hook address (e.g. from an indexer `Pool.positionManager`) is a v1.3 hook.
+ */
+export function getV1_3PositionManagers(chainId: number): Address[] {
+  const current = PairedTokenPositionManagerV1_3Address[chainId];
+  return [
+    ...(current ? [current] : []),
+    ...(SupersededPositionManagerV1_3Address[chainId] ?? []),
+  ];
 }

--- a/src/sdk/FlaunchSDK.ts
+++ b/src/sdk/FlaunchSDK.ts
@@ -51,6 +51,7 @@ import {
   FlaunchV1_2Address,
   // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663)
   FlaunchPositionManagerV1_3Address,
+  SupersededPositionManagerV1_3Address,
   FlaunchZapV1_3Address,
   PairedTokenPositionManagerV1_3Address,
   PairedTokenRegistryV1_3Address,
@@ -1097,10 +1098,16 @@ export class ReadFlaunchSDK {
   getPoolCreatedFromLogs(logs: readonly Log[]): PoolCreatedEventData | null {
     const positionManagerV1_3 =
       PairedTokenPositionManagerV1_3Address[this.chainId];
+    // A chain can carry more than one v1.3 hook generation (Robinhood: the v1.3.1 hooks were
+    // regenerated as v1.3.3); a receipt from either is a v1.3 PoolCreated.
+    const v1_3Hooks = [
+      ...(positionManagerV1_3 ? [positionManagerV1_3] : []),
+      ...(SupersededPositionManagerV1_3Address[this.chainId] ?? []),
+    ];
 
-    if (positionManagerV1_3) {
+    if (v1_3Hooks.length > 0) {
       for (const log of logs) {
-        if (!isAddressEqual(log.address, positionManagerV1_3)) {
+        if (!v1_3Hooks.some((hook) => isAddressEqual(log.address, hook))) {
           continue;
         }
 

--- a/test/managersV1_3.test.cjs
+++ b/test/managersV1_3.test.cjs
@@ -35,6 +35,9 @@ const {
   GroupMapperV1_3Address,
   FlaunchManagerZapV1_3Address,
   WhitelistedPermissionsV1_3Address,
+  SupersededPositionManagerV1_3Address,
+  FlaunchPositionManagerV1_3Address,
+  getV1_3PositionManagers,
   FlaunchManagerZapV1_3Abi,
   RevenueManagerV1_3Abi,
   TreasuryManagerV1_3Abi,
@@ -142,9 +145,21 @@ test("the v1.3.1 manager generation is pinned to the Base and Robinhood releases
   // ClosedPermissions is factory-agnostic and reused by the new generation
   assert.equal(getAddress(ClosedPermissionsAddress[base.id]), "0x4dfc76A31A2a0110739611683a8b6C5201480fa1");
   assert.equal(getAddress(ClosedPermissionsAddress[robinhood.id]), "0xF0469beF728c498f3621008C65B95EDa56C82Ae3");
-  // the redeployed core zaps, bound to each chain's v1.3.1 factory (replace 0x29b37dfe… / 0x2e744436…)
+  // the core zaps bound to each chain's v1.3.1 factory: Base's 08-27 rebind, Robinhood's v1.3.3
+  // regeneration zap (deployed bound in-run; supersedes the 09-02 rebind 0xFCd1eB4B… and the
+  // factory-less 0x2e744436…). PREDICTED from the fork rehearsal — confirm from the broadcast.
   assert.equal(getAddress(FlaunchZapV1_3Address[base.id]), "0xf787d757674b21efD713fB636B16ed994bfa82A8");
-  assert.equal(getAddress(FlaunchZapV1_3Address[robinhood.id]), "0xFCd1eB4BFA9A97059CaF4D160d28C871F5f3077a");
+  assert.equal(getAddress(FlaunchZapV1_3Address[robinhood.id]), "0x740f8278Fd9C548fF50b64805337eA8Ad24b2553");
+  // Robinhood's superseded v1.3.1 hooks stay resolvable for the coins that live on them.
+  assert.deepEqual(
+    SupersededPositionManagerV1_3Address[robinhood.id].map((a) => a.toLowerCase()),
+    ["0x588c683ecc450f8b2aadb13d7f63792b840425dc", "0x6ea0edee449a287504990df8d87951b9436825dc"]
+  );
+  assert.equal(SupersededPositionManagerV1_3Address[base.id], undefined);
+  assert.deepEqual(
+    getV1_3PositionManagers(robinhood.id).map((a) => a.toLowerCase()),
+    [FlaunchPositionManagerV1_3Address[robinhood.id].toLowerCase(), "0x588c683ecc450f8b2aadb13d7f63792b840425dc", "0x6ea0edee449a287504990df8d87951b9436825dc"]
+  );
   assert.equal(doesChainSupportMultiAssetManagers(robinhood.id), true);
 
   assert.equal(doesChainSupportMultiAssetManagers(base.id), true);

--- a/test/managersV1_3.test.cjs
+++ b/test/managersV1_3.test.cjs
@@ -147,7 +147,7 @@ test("the v1.3.1 manager generation is pinned to the Base and Robinhood releases
   assert.equal(getAddress(ClosedPermissionsAddress[robinhood.id]), "0xF0469beF728c498f3621008C65B95EDa56C82Ae3");
   // the core zaps bound to each chain's v1.3.1 factory: Base's 08-27 rebind, Robinhood's v1.3.3
   // regeneration zap (deployed bound in-run; supersedes the 09-02 rebind 0xFCd1eB4B… and the
-  // factory-less 0x2e744436…). PREDICTED from the fork rehearsal — confirm from the broadcast.
+  // factory-less 0x2e744436…). Live on 4663 since 2026-09-03.
   assert.equal(getAddress(FlaunchZapV1_3Address[base.id]), "0xf787d757674b21efD713fB636B16ed994bfa82A8");
   assert.equal(getAddress(FlaunchZapV1_3Address[robinhood.id]), "0x740f8278Fd9C548fF50b64805337eA8Ad24b2553");
   // Robinhood's superseded v1.3.1 hooks stay resolvable for the coins that live on them.


### PR DESCRIPTION
## Summary
- Robinhood (4663) rows of the `*V1_3Address` hook/NFT/BidWall/zap/importer/referral maps move to the v1.3.3 regeneration (live 2026-09-03, blocks 53313466–53315211; flaunch-contracts PR for the record). Registry, escrow, factory, managers, flETH and PoolSwap rows are unchanged.
- New `SupersededPositionManagerV1_3Address` (Robinhood's 08-21 hooks `0x588c683e…` / `0x6ea0edee…`, which still serve their pools) and `getV1_3PositionManagers(chainId)`; `getPoolCreatedFromLogs` accepts a `PoolCreated` from any current or superseded v1.3 hook.
- CHANGELOG 0.11.2, version bump.

## Test plan
- [x] `pnpm test` 46/46
- [ ] after merge: `pnpm publish` from master (interactive 2FA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)