### PR TITLE
fix: resolve the hook per coin on multichain deployments (FLA2-397) — 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to the @flaunch/sdk package will be documented in this file.
 
-## [0.11.2] - UNRELEASED (prepared 2026-09-02)
+## [0.11.3] - UNRELEASED (prepared 2026-09-03)
+
+### Fixed
+
+- **Swaps and quotes on multichain deployments resolve the hook per coin (FLA2-397).** On Robinhood the SDK always built pool keys from the chain's multichain (v1.2) hook, so `buyCoin`, `sellCoin`, `getBuyQuoteExactInput`/`ExactOutput`, `getSellQuoteExactInput` and `poolId` reverted at the quoter for every v1.3.x coin. `getPositionManagerAddressForCoin(coinAddress, version?)` now probes the current and superseded v1.3 hooks (`getV1_3PositionManagers`) and then the multichain hook, caching the answer per coin; the swap and quote paths use it. `isValidCoin` and `getCoinVersion` work on multichain deployments instead of throwing. Note: on a multichain deployment these calls now read the chain (one `poolKey` per candidate hook, cached per coin) unless a `version` is passed explicitly.
+
+## [0.11.2] - 2026-09-03
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaunch/sdk",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Flaunch SDK to easily interact with the Flaunch protocol",
   "license": "MIT",
   "author": "Apoorv Lathey <apoorv@flayer.io>",

--- a/src/sdk/FlaunchSDK.ts
+++ b/src/sdk/FlaunchSDK.ts
@@ -223,6 +223,7 @@ import { ReadTrustedSignerFeeCalculator } from "clients/TrustedSignerFeeCalculat
 import {
   isChainSupported,
   isMultichainDeployment,
+  getV1_3PositionManagers,
   doesChainSupportMultiAssetManagers,
   doesChainSupportPairedTokenLaunch,
 } from "helpers/supportedChains";
@@ -718,12 +719,90 @@ export class ReadFlaunchSDK {
     return this.readFlaunchZapV1_3.calculateFee(params);
   }
 
+  /** Per-coin hook resolution results on multichain deployments (a coin never changes hook). */
+  private multichainCoinHooks = new Map<string, { hook: Address; version: FlaunchVersion } | null>();
+
+  /**
+   * On a multichain deployment a chain can serve several hook generations at once (Robinhood:
+   * the v1.2 multichain hook, the 2026-08-21 v1.3.1 hooks and the v1.3.3 regeneration). Every
+   * pool key — and so every quote and swap — derives from the hook the coin was created on, so
+   * it has to be probed per coin rather than taken from the chain's current default. Probes the
+   * current and superseded v1.3 hooks first, then the multichain (v1.2) hook.
+   * @returns The coin's hook and version, or null when no hook on this chain knows the coin.
+   */
+  protected async probeMultichainCoinHook(
+    coinAddress: Address
+  ): Promise<{ hook: Address; version: FlaunchVersion } | null> {
+    const key = coinAddress.toLowerCase();
+    const cached = this.multichainCoinHooks.get(key);
+    if (cached !== undefined) return cached;
+
+    const isValidOn = async (hook: Address) => {
+      try {
+        return await new ReadFlaunchPositionManagerV1_2(
+          hook,
+          this.drift
+        ).isValidCoin(coinAddress);
+      } catch {
+        return false;
+      }
+    };
+
+    let result: { hook: Address; version: FlaunchVersion } | null = null;
+    for (const hook of getV1_3PositionManagers(this.chainId)) {
+      if (await isValidOn(hook)) {
+        result = { hook, version: FlaunchVersion.V1_3 };
+        break;
+      }
+    }
+    if (!result) {
+      const multichainHook = FlaunchPositionManagerMultichainAddress[this.chainId];
+      if (multichainHook && (await isValidOn(multichainHook))) {
+        result = { hook: multichainHook, version: FlaunchVersion.V1_2 };
+      }
+    }
+
+    this.multichainCoinHooks.set(key, result);
+    return result;
+  }
+
+  /**
+   * The hook (PositionManager) a coin's pool lives on. On Base this is the position manager
+   * for the coin's version; on a multichain deployment it is probed per coin (see
+   * `probeMultichainCoinHook`), falling back to the chain's multichain hook for an unknown coin.
+   * @param coinAddress - The coin to resolve
+   * @param version - Optional version override (skips detection on Base; on multichain a
+   *   non-v1.3 version short-circuits to the multichain hook)
+   */
+  async getPositionManagerAddressForCoin(
+    coinAddress: Address,
+    version?: FlaunchVersion
+  ): Promise<Address> {
+    if (!isMultichainDeployment(this.chainId)) {
+      return this.getPositionManagerAddress(
+        await this.determineCoinVersion(coinAddress, version)
+      );
+    }
+    if (
+      version !== undefined &&
+      version !== FlaunchVersion.V1_3 &&
+      version !== FlaunchVersion.ANY
+    ) {
+      return FlaunchPositionManagerMultichainAddress[this.chainId];
+    }
+    const probed = await this.probeMultichainCoinHook(coinAddress);
+    return probed?.hook ?? FlaunchPositionManagerMultichainAddress[this.chainId];
+  }
+
   /**
    * Checks if a given coin address is a valid Flaunch coin (supports all versions)
    * @param coinAddress - The address of the coin to check
    * @returns Promise<boolean> - True if the coin is valid, false otherwise
    */
   async isValidCoin(coinAddress: Address) {
+    if (isMultichainDeployment(this.chainId)) {
+      return (await this.probeMultichainCoinHook(coinAddress)) !== null;
+    }
     return (
       (this.readPositionManagerV1_3
         ? await this.readPositionManagerV1_3.isValidCoin(coinAddress)
@@ -741,6 +820,11 @@ export class ReadFlaunchSDK {
    * @returns Promise<FlaunchVersion> - The version of the coin
    */
   async getCoinVersion(coinAddress: Address): Promise<FlaunchVersion> {
+    if (isMultichainDeployment(this.chainId)) {
+      const probed = await this.probeMultichainCoinHook(coinAddress);
+      if (probed) return probed.version;
+      throw new Error(`Unknown coin version for address: ${coinAddress}`);
+    }
     if (
       this.readPositionManagerV1_3 &&
       (await this.readPositionManagerV1_3.isValidCoin(coinAddress))
@@ -1954,10 +2038,10 @@ export class ReadFlaunchSDK {
    * @returns Promise<string> - The pool ID
    */
   async poolId(coinAddress: Address, version?: FlaunchVersion) {
-    let hookAddress: Address;
-
-    const coinVersion = await this.determineCoinVersion(coinAddress, version);
-    hookAddress = this.getPositionManagerAddress(coinVersion);
+    const hookAddress = await this.getPositionManagerAddressForCoin(
+      coinAddress,
+      version
+    );
 
     return getPoolId(
       orderPoolKey({
@@ -2053,12 +2137,15 @@ export class ReadFlaunchSDK {
     amountIn: bigint;
     intermediatePoolKey?: PoolWithHookData;
   }) {
-    const coinVersion = await this.determineCoinVersion(coinAddress, version);
+    const hookAddress = await this.getPositionManagerAddressForCoin(
+      coinAddress,
+      version
+    );
 
     return this.readQuoter.getSellQuoteExactInput({
       coinAddress,
       amountIn,
-      positionManagerAddress: this.getPositionManagerAddress(coinVersion),
+      positionManagerAddress: hookAddress,
       intermediatePoolKey,
     });
   }
@@ -2088,12 +2175,15 @@ export class ReadFlaunchSDK {
     hookData?: Hex;
     userWallet?: Address;
   }) {
-    const coinVersion = await this.determineCoinVersion(coinAddress, version);
+    const hookAddress = await this.getPositionManagerAddressForCoin(
+      coinAddress,
+      version
+    );
 
     return this.readQuoter.getBuyQuoteExactInput({
       coinAddress,
       amountIn,
-      positionManagerAddress: this.getPositionManagerAddress(coinVersion),
+      positionManagerAddress: hookAddress,
       intermediatePoolKey,
       hookData,
       userWallet,
@@ -2125,12 +2215,15 @@ export class ReadFlaunchSDK {
     hookData?: Hex;
     userWallet?: Address;
   }) {
-    const coinVersion = await this.determineCoinVersion(coinAddress, version);
+    const hookAddress = await this.getPositionManagerAddressForCoin(
+      coinAddress,
+      version
+    );
 
     return this.readQuoter.getBuyQuoteExactOutput({
       coinAddress,
       coinOut: amountOut,
-      positionManagerAddress: this.getPositionManagerAddress(coinVersion),
+      positionManagerAddress: hookAddress,
       intermediatePoolKey,
       hookData,
       userWallet,
@@ -3173,7 +3266,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
    * @returns Transaction response for the buy operation
    */
   async buyCoin(params: BuyCoinParams, version?: FlaunchVersion) {
-    const coinVersion = await this.determineCoinVersion(
+    const hookAddress = await this.getPositionManagerAddressForCoin(
       params.coinAddress,
       version
     );
@@ -3194,7 +3287,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
           amount: await this.readQuoter.getBuyQuoteExactInput({
             coinAddress: params.coinAddress,
             amountIn,
-            positionManagerAddress: this.getPositionManagerAddress(coinVersion),
+            positionManagerAddress: hookAddress,
             intermediatePoolKey: params.intermediatePoolKey,
             hookData: params.hookData,
             userWallet: sender,
@@ -3212,7 +3305,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
           amount: await this.readQuoter.getBuyQuoteExactOutput({
             coinAddress: params.coinAddress,
             coinOut: amountOut,
-            positionManagerAddress: this.getPositionManagerAddress(coinVersion),
+            positionManagerAddress: hookAddress,
             intermediatePoolKey: params.intermediatePoolKey,
             hookData: params.hookData,
             userWallet: sender,
@@ -3235,7 +3328,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
       amountOutMin: amountOutMin,
       amountOut: amountOut,
       amountInMax: amountInMax,
-      positionManagerAddress: this.getPositionManagerAddress(coinVersion),
+      positionManagerAddress: hookAddress,
       intermediatePoolKey: params.intermediatePoolKey,
       permitSingle: params.permitSingle,
       signature: params.signature,
@@ -3265,7 +3358,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
    * @returns Transaction response for the sell operation
    */
   async sellCoin(params: SellCoinParams, version?: FlaunchVersion) {
-    const coinVersion = await this.determineCoinVersion(
+    const hookAddress = await this.getPositionManagerAddressForCoin(
       params.coinAddress,
       version
     );
@@ -3279,7 +3372,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
         amount: await this.readQuoter.getSellQuoteExactInput({
           coinAddress: params.coinAddress,
           amountIn: params.amountIn,
-          positionManagerAddress: this.getPositionManagerAddress(coinVersion),
+          positionManagerAddress: hookAddress,
           intermediatePoolKey: params.intermediatePoolKey,
         }),
         slippage: (params.slippagePercent / 100).toFixed(18).toString(),
@@ -3299,7 +3392,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
       permitSingle: params.permitSingle,
       signature: params.signature,
       referrer: params.referrer ?? null,
-      positionManagerAddress: this.getPositionManagerAddress(coinVersion),
+      positionManagerAddress: hookAddress,
       intermediatePoolKey: params.intermediatePoolKey,
     });
 

--- a/test/multichainSwapHooks.test.cjs
+++ b/test/multichainSwapHooks.test.cjs
@@ -1,0 +1,131 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { robinhood } = require("viem/chains");
+const {
+  FlaunchPositionManagerMultichainAddress,
+  FlaunchVersion,
+  PairedTokenPositionManagerV1_3Address,
+  ReadFlaunchSDK,
+  SupersededPositionManagerV1_3Address,
+} = require("../dist/index.cjs.js");
+
+// FLA2-397: on a multichain deployment every quote and swap used the chain's v1.2 multichain
+// hook, so v1.3.x coins reverted at the quoter. The SDK must resolve the hook per coin.
+
+const V133_HOOK = PairedTokenPositionManagerV1_3Address[robinhood.id];
+const SUPERSEDED_HOOK = SupersededPositionManagerV1_3Address[robinhood.id][0];
+const V12_HOOK = FlaunchPositionManagerMultichainAddress[robinhood.id];
+
+const V133_COIN = "0x411bE1f78cfEcDBdA70D57642895C1dD64bA3986"; // V133C
+const OLD_COIN = "0xfc5633E8CAf9Ec6C6f2a483F2013b57A741bA6C5"; // RHCANARY (2026-08-21 hooks)
+const V12_COIN = "0x7FB6e53a849FCC363dF7b7AF46111B42BD225F42";
+const UNKNOWN_COIN = "0x9999999999999999999999999999999999999999";
+const SENDER = "0x1111111111111111111111111111111111111111";
+
+const lower = (a) => a.toLowerCase();
+
+/** A drift stub whose position managers each know exactly the coins in `poolsByHook`. */
+function makeDrift(poolsByHook) {
+  const simulations = [];
+  const reads = [];
+  const drift = {
+    contract({ address }) {
+      return {
+        address,
+        cache: { clear: async () => {} },
+        async read(fn, args) {
+          reads.push({ address, fn, args });
+          if (fn === "poolKey") {
+            const coins = poolsByHook[lower(address)] ?? [];
+            const known = coins.some((c) => lower(c) === lower(args._token));
+            return {
+              currency0: "0x0000000000000000000000000000000000000000",
+              currency1: args._token,
+              fee: 0,
+              tickSpacing: known ? 60 : 0,
+              hooks: address,
+            };
+          }
+          throw new Error(`unexpected read ${fn} on ${address}`);
+        },
+        async simulateWrite(fn, args, options) {
+          simulations.push({ address, fn, args, options });
+          return { amountOut: 123n };
+        },
+      };
+    },
+  };
+  return { drift, simulations, reads };
+}
+
+const pools = {
+  [lower(V133_HOOK)]: [V133_COIN],
+  [lower(SUPERSEDED_HOOK)]: [OLD_COIN],
+  [lower(V12_HOOK)]: [V12_COIN],
+};
+
+test("resolves the current v1.3 hook for a v1.3.3 coin on Robinhood", async () => {
+  const { drift } = makeDrift(pools);
+  const sdk = new ReadFlaunchSDK(robinhood.id, drift);
+  assert.equal(lower(await sdk.getPositionManagerAddressForCoin(V133_COIN)), lower(V133_HOOK));
+  assert.equal(await sdk.getCoinVersion(V133_COIN), FlaunchVersion.V1_3);
+  assert.equal(await sdk.isValidCoin(V133_COIN), true);
+});
+
+test("resolves a superseded v1.3 hook for a coin still living on it", async () => {
+  const { drift } = makeDrift(pools);
+  const sdk = new ReadFlaunchSDK(robinhood.id, drift);
+  assert.equal(lower(await sdk.getPositionManagerAddressForCoin(OLD_COIN)), lower(SUPERSEDED_HOOK));
+  assert.equal(await sdk.getCoinVersion(OLD_COIN), FlaunchVersion.V1_3);
+});
+
+test("falls back to the multichain (v1.2) hook for a v1.2 coin and for an unknown coin", async () => {
+  const { drift } = makeDrift(pools);
+  const sdk = new ReadFlaunchSDK(robinhood.id, drift);
+  assert.equal(lower(await sdk.getPositionManagerAddressForCoin(V12_COIN)), lower(V12_HOOK));
+  assert.equal(await sdk.getCoinVersion(V12_COIN), FlaunchVersion.V1_2);
+  assert.equal(lower(await sdk.getPositionManagerAddressForCoin(UNKNOWN_COIN)), lower(V12_HOOK));
+  assert.equal(await sdk.isValidCoin(UNKNOWN_COIN), false);
+  await assert.rejects(() => sdk.getCoinVersion(UNKNOWN_COIN), /Unknown coin version/);
+});
+
+test("buy quotes route through the coin's own hook and cache the probe", async () => {
+  const { drift, simulations, reads } = makeDrift(pools);
+  const sdk = new ReadFlaunchSDK(robinhood.id, drift);
+
+  await sdk.getBuyQuoteExactInput({ coinAddress: V133_COIN, amountIn: 10n ** 15n, userWallet: SENDER });
+  await sdk.getBuyQuoteExactInput({ coinAddress: OLD_COIN, amountIn: 10n ** 15n, userWallet: SENDER });
+  await sdk.getBuyQuoteExactInput({ coinAddress: V133_COIN, amountIn: 2n * 10n ** 15n, userWallet: SENDER });
+
+  assert.equal(simulations.length, 3);
+  const hooksIn = (sim) =>
+    JSON.stringify(sim.args, (_k, v) => (typeof v === "bigint" ? v.toString() : v)).toLowerCase();
+  assert.ok(hooksIn(simulations[0]).includes(lower(V133_HOOK)));
+  assert.ok(!hooksIn(simulations[0]).includes(lower(V12_HOOK)));
+  assert.ok(hooksIn(simulations[1]).includes(lower(SUPERSEDED_HOOK)));
+  assert.ok(hooksIn(simulations[2]).includes(lower(V133_HOOK)));
+
+  // The second V133C quote must not probe again: one poolKey read per hook tried, once per coin.
+  const poolKeyReadsForV133 = reads.filter(
+    (r) => r.fn === "poolKey" && lower(r.args._token) === lower(V133_COIN)
+  );
+  assert.equal(poolKeyReadsForV133.length, 1);
+});
+
+test("poolId differs per hook generation for the same paired token", async () => {
+  const { drift } = makeDrift(pools);
+  const sdk = new ReadFlaunchSDK(robinhood.id, drift);
+  const a = await sdk.poolId(V133_COIN);
+  const b = await sdk.poolId(V12_COIN);
+  assert.notEqual(a, b);
+});
+
+test("an explicit non-v1.3 version short-circuits to the multichain hook without probing", async () => {
+  const { drift, reads } = makeDrift(pools);
+  const sdk = new ReadFlaunchSDK(robinhood.id, drift);
+  assert.equal(
+    lower(await sdk.getPositionManagerAddressForCoin(V133_COIN, FlaunchVersion.V1_2)),
+    lower(V12_HOOK)
+  );
+  assert.equal(reads.length, 0);
+});

--- a/test/nativeEthSwap.test.cjs
+++ b/test/nativeEthSwap.test.cjs
@@ -11,6 +11,7 @@ const { robinhood } = require("viem/chains");
 const {
   FLETHAddress,
   FlaunchPositionManagerMultichainAddress,
+  FlaunchVersion,
   Permit2Address,
   QuoterAddress,
   ReadFlaunchSDK,
@@ -132,13 +133,18 @@ test("Robinhood native ETH buys target the deployed Universal Router", async () 
     walletAddress: SENDER,
   });
 
-  const encodedCall = await sdk.buyCoin({
-    coinAddress: COIN,
-    swapType: "EXACT_IN",
-    amountIn: 1_000_000_000_000_000n,
-    amountOutMin: 100n,
-    slippagePercent: 0.5,
-  });
+  // With amountOutMin supplied no quote is needed; passing the version skips the per-coin hook
+  // probe too (FLA2-397), so the whole build is offline — the transport must never be hit.
+  const encodedCall = await sdk.buyCoin(
+    {
+      coinAddress: COIN,
+      swapType: "EXACT_IN",
+      amountIn: 1_000_000_000_000_000n,
+      amountOutMin: 100n,
+      slippagePercent: 0.5,
+    },
+    FlaunchVersion.V1_2
+  );
   const transaction = decodeCallData(encodedCall);
   const routerCall = decodeFunctionData({
     abi: UniversalRouterAbi,


### PR DESCRIPTION
## Why (FLA2-397)

On a multichain deployment `determineCoinVersion` returned `ANY` and `getPositionManagerAddress` always returned `FlaunchPositionManagerMultichainAddress` (the v1.2 hook). Every pool key — and so every quote and swap — was built against that hook, so on Robinhood `buyCoin`/`sellCoin`/`getBuyQuoteExactInput`/`getBuyQuoteExactOutput`/`getSellQuoteExactInput`/`poolId` reverted at the quoter (`0x8Dc178…`) for every v1.3.x coin (both the 2026-08-21 hooks and v1.3.3). Reproduced live via flaunch-mcp `swap/prepare` for V133C and RHCANARY.

## What

- `getPositionManagerAddressForCoin(coinAddress, version?)`: on Base, the position manager for the detected version as before; on a multichain deployment, probes `getV1_3PositionManagers(chainId)` (current + superseded v1.3 hooks) then the multichain hook via `poolKey(coin).tickSpacing != 0`, caches per coin, falls back to the multichain hook for an unknown coin. An explicit non-v1.3 `version` short-circuits with no reads.
- All swap/quote paths and `poolId` use it.
- `isValidCoin` / `getCoinVersion` work on multichain deployments (previously threw "not supported").
- `test/multichainSwapHooks.test.cjs`: 6 cases (v1.3.3 coin, superseded-hook coin, v1.2 coin + unknown, quote routing + probe cache, poolId per generation, explicit-version short-circuit). `nativeEthSwap` offline-build test passes the version explicitly. 51/51.
- CHANGELOG 0.11.3; version bump.

Consumer follow-up: flaunch-mcp pins 0.11.3 (no code change needed — it already calls `buyCoin`/`sellCoin` without a version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)