### PR TITLE
fix: add-liquidity helpers build the pool key from the coin's own hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the @flaunch/sdk package will be documented in this file.
 ### Fixed
 
 - **Swaps and quotes on multichain deployments resolve the hook per coin (FLA2-397).** On Robinhood the SDK always built pool keys from the chain's multichain (v1.2) hook, so `buyCoin`, `sellCoin`, `getBuyQuoteExactInput`/`ExactOutput`, `getSellQuoteExactInput` and `poolId` reverted at the quoter for every v1.3.x coin. `getPositionManagerAddressForCoin(coinAddress, version?)` now probes the current and superseded v1.3 hooks (`getV1_3PositionManagers`) and then the multichain hook, caching the answer per coin; the swap and quote paths use it. `isValidCoin` and `getCoinVersion` work on multichain deployments instead of throwing. Note: on a multichain deployment these calls now read the chain (one `poolKey` per candidate hook, cached per coin) unless a `version` is passed explicitly.
+- **Add-liquidity helpers use the coin's hook too.** `checkSingleSidedAddLiquidity`, `calculateAddLiquidityAmounts`, `getAddLiquidityCalls` and `getSingleSidedCoinAddLiquidityCalls` built their pool key from the version-based getter, so on Robinhood they read and targeted the v1.2 hook's pool for v1.3.x coins. They now go through `createPoolKeyForCoin`.
 
 ## [0.11.2] - 2026-09-03
 

--- a/src/sdk/FlaunchSDK.ts
+++ b/src/sdk/FlaunchSDK.ts
@@ -2553,13 +2553,10 @@ export class ReadFlaunchSDK {
 
     // If no current tick is provided from the above calculation, get it from the pool state
     if (!currentTick) {
-      const version = await this.determineCoinVersion(
-        coinAddress,
-        params.version
-      );
-
       const poolState = await this.readStateView.poolSlot0({
-        poolId: getPoolId(this.createPoolKey(coinAddress, version)),
+        poolId: getPoolId(
+          await this.createPoolKeyForCoin(coinAddress, params.version)
+        ),
       });
       currentTick = poolState.tick;
     }
@@ -2659,13 +2656,10 @@ export class ReadFlaunchSDK {
 
     // get the current pool state for the coin
     if (!currentTick) {
-      const version = await this.determineCoinVersion(
-        coinAddress,
-        params.version
-      );
-
       const poolState = await this.readStateView.poolSlot0({
-        poolId: getPoolId(this.createPoolKey(coinAddress, version)),
+        poolId: getPoolId(
+          await this.createPoolKeyForCoin(coinAddress, params.version)
+        ),
       });
       currentTick = poolState.tick;
     }
@@ -2875,6 +2869,25 @@ export class ReadFlaunchSDK {
       fee: 0,
       tickSpacing: this.TICK_SPACING,
       hooks: this.getPositionManagerAddress(version),
+    });
+  }
+
+  /**
+   * `createPoolKey` resolved by coin rather than by version: on a multichain deployment the
+   * hook is probed per coin (see `getPositionManagerAddressForCoin`), so the key matches the
+   * pool the coin was actually created on. The liquidity helpers use this.
+   */
+  protected async createPoolKeyForCoin(
+    coinAddress: Address,
+    version?: FlaunchVersion
+  ) {
+    const flethAddress = FLETHAddress[this.chainId];
+    return orderPoolKey({
+      currency0: coinAddress,
+      currency1: flethAddress,
+      fee: 0,
+      tickSpacing: this.TICK_SPACING,
+      hooks: await this.getPositionManagerAddressForCoin(coinAddress, version),
     });
   }
 }
@@ -3777,7 +3790,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
       coinAddress,
       params.version
     );
-    const poolKey = this.createPoolKey(coinAddress, version);
+    const poolKey = await this.createPoolKeyForCoin(coinAddress, params.version);
 
     // Check if we need to calculate values or use direct values
     if ("tickLower" in params) {
@@ -4158,7 +4171,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
       coinAddress,
       params.version
     );
-    const poolKey = this.createPoolKey(coinAddress, version);
+    const poolKey = await this.createPoolKeyForCoin(coinAddress, params.version);
 
     let currentTick: number;
 

--- a/test/multichainSwapHooks.test.cjs
+++ b/test/multichainSwapHooks.test.cjs
@@ -6,6 +6,7 @@ const {
   FlaunchVersion,
   PairedTokenPositionManagerV1_3Address,
   ReadFlaunchSDK,
+  ReadWriteFlaunchSDK,
   SupersededPositionManagerV1_3Address,
 } = require("../dist/index.cjs.js");
 
@@ -128,4 +129,20 @@ test("an explicit non-v1.3 version short-circuits to the multichain hook without
     lower(V12_HOOK)
   );
   assert.equal(reads.length, 0);
+});
+
+test("add-liquidity helpers resolve the coin's hook before touching pool state", async () => {
+  const { drift, reads } = makeDrift(pools);
+  // The liquidity helpers live on the read-write SDK. On Robinhood the SDK has no state-view
+  // client, so the helper stops at `readStateView` — but only AFTER building the pool key, which
+  // must now come from a per-coin probe rather than the chain's default hook.
+  const sdk = new ReadWriteFlaunchSDK(robinhood.id, drift);
+
+  await assert.rejects(
+    () => sdk.getSingleSidedCoinAddLiquidityCalls({ coinAddress: V133_COIN, coinAmount: 10n ** 18n }),
+    /readStateView is not supported on chain 4663/
+  );
+  const probes = reads.filter((r) => r.fn === "poolKey" && lower(r.args._token) === lower(V133_COIN));
+  assert.equal(probes.length, 1, "the coin's hook was probed exactly once");
+  assert.equal(lower(probes[0].address), lower(V133_HOOK));
 });


### PR DESCRIPTION
Follow-up to #31 (FLA2-397), same 0.11.3 release.

The four add-liquidity helpers — `checkSingleSidedAddLiquidity`, `calculateAddLiquidityAmounts`, `getAddLiquidityCalls`, `getSingleSidedCoinAddLiquidityCalls` — still built their pool key via `createPoolKey(coin, version)`, i.e. the version-based hook getter that resolves to the v1.2 multichain hook on Robinhood. For a v1.3.x coin that is the wrong pool. They now use `createPoolKeyForCoin`, which routes through the per-coin probe from #31. Base is unchanged (non-multichain branch is the previous two calls).

Note for the record: on Robinhood these helpers currently stop at `readStateView is not supported on chain 4663` — the SDK wires no state-view client for multichain deployments — so they were unreachable there anyway. This makes them correct for when that client is added; the new test asserts the coin's hook is probed before the state-view lookup. 53/53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)