### PR TITLE
docs: mark 0.11.3 as released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the @flaunch/sdk package will be documented in this file.
 
-## [0.11.3] - UNRELEASED (prepared 2026-09-03)
+## [0.11.3] - 2026-09-03
 
 ### Fixed
 


### PR DESCRIPTION
0.11.3 was published to npm at 2026-09-03T15:38:57Z from master `23309bd` (#31 + #32). The changelog header still read `UNRELEASED (prepared 2026-09-03)`; this sets the release date so master's changelog matches the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)