### PR TITLE
docs: quote the $4K starting market cap in the launch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ const hash = await flaunchWrite.flaunchIPFS({
   symbol: "TEST",
   fairLaunchPercent: 0, // 0%
   fairLaunchDuration: 30 * 60, // 30 mins
-  initialMarketCapUSD: 10_000, // $10k
+  initialMarketCapUSD: 4_000, // $4k
   creator: address,
   creatorFeeAllocationPercent: 80, // 80% to creator, 20% to community
   metadata: {


### PR DESCRIPTION
Every Flaunch launch entrypoint now defaults to a **$4K** starting market cap, so the README's launch snippet shouldn't keep teaching `$10k`.

**Docs only.** The SDK itself holds no default and stays a pass-through — `initialMarketCapUSD` is a required caller param on every client (`FlaunchZapClient`, `FlaunchZapMultichainClient`, `FlaunchPositionManager{,V1_1,V1_2}Client`, `AnyPositionManagerClient`, `TokenImporter`). Nothing about the API changes.

The **import** examples keep their own figures: importing values an *existing* token at what it's worth, which a launch default doesn't govern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)