### PR TITLE
feat(sdk): support Ethereum v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.15.0] - 2026-09-11
+
+### Added
+- Verified Ethereum mainnet v1.4.0 core and multi-asset manager addresses through the compatible `*V1_3` API family, including the protected PoolSwap router.
+- Native ETH as Ethereum's default pairing, with direct MILADY and LIL paired launches and swaps. Historical flETH address maps remain available for legacy pools.
+- Ethereum plain, IPFS and managed launch dispatch, current multi-token creator fee claims, and AnyPositionManager pool/NFT discovery.
+
+### Fixed
+- Plain and managed launch ABI overload selection retains the correct tuple shape for each call.
+- Ethereum pool reads and protected swap planning use the deployed pool's actual currencies and hook. Legacy flETH swap helpers reject current pools.
+- Native launch pricing reads the deployed ETH/USD oracle. NFTX pairings do not imply ETH acquisition routing or Game Mode support.
+
 ## [0.14.0] - 2026-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A TypeScript SDK for seamless interaction with the Flaunch protocol and Uniswap V4.
 
-> This protected-swap branch is release-blocked. Its planner requires new router capabilities not supplied by the current legacy address maps. Follow [the coordinated release gates](./PROTECTED_SWAP_RELEASE.md); do not publish or deploy a dependency-only upgrade.
+> Protected paired-token swaps require a router exposing `exactInputVersion() == 1`. The current Base, Base Sepolia, Robinhood and Ethereum router maps target this generation; unsupported routers fail closed. See the [protected-swap release record](./PROTECTED_SWAP_RELEASE.md).
 
 ![Flaunch Header](https://raw.githubusercontent.com/flayerlabs/flaunch-sdk/refs/heads/master/.github/flaunch-header.png)
 
@@ -22,9 +22,13 @@ _Note: Add this `llms-full.txt` file into Cursor IDE / LLMs to provide context a
 
 ## Network support
 
-Base and Base Sepolia retain their generation-specific launch paths. Ethereum, Unichain, and Robinhood support standard direct launches, existing-manager launches, static and dynamic address fee split launches, the IPFS metadata helper, `PoolCreated` receipt decoding, and creator fee claims through the legacy multichain zap. This does not add v1.3 paired-token manager launches or general multichain liquidity support. Robinhood also supports native ETH swaps and paired-token launches through their separate capability-gated paths.
+Base and Base Sepolia retain their generation-specific launch paths. Unichain and Robinhood retain their legacy multichain launch helpers. Robinhood also supports native ETH swaps and paired-token launches through their separate capability-gated paths.
 
-The v1.3.1 multi-asset manager generation has address mappings for Base, Base Sepolia, and Robinhood. Gate these separate `*V1_3` APIs with `doesChainSupportMultiAssetManagers()`; legacy manager helpers do not select that generation automatically.
+Ethereum uses the verified [v1.4.0 deployment](https://github.com/flayerlabs/flaunch-contracts/releases/tag/v1.4.0), through the compatible `*V1_3` API family. `flaunch()` and its IPFS and manager-launch helpers default to native ETH and the current manager generation. `DefaultPairedTokenAddress[1]` is `zeroAddress`; `FLETHAddress[1]` and the old multichain maps remain available for legacy pools.
+
+Ethereum supports native ETH, MILADY (`0x8b3bc6942d6823a8022605648b671a2feb954800`) and LIL (`0x370e49749b9ff90004f3186aa7135487acc2a8fc`) through `flaunchPairedToken()`, `quotePairedPool()` and protected `planPairedTokenSwap()` / `buyCoinPairedToken()` / `sellCoinPairedToken()`. ERC20 premines require the caller to hold and approve the paired token to `FlaunchZapV1_3Address[1]`. ETH-to-NFTX-token acquisition and Game Mode are not included. Legacy flETH swap helpers reject current Ethereum pools. ETH/USD reads use the deployed launch oracle's 30-minute WETH/USDC V3 TWAP.
+
+The multi-asset manager generation has address mappings for Base, Base Sepolia, Robinhood and Ethereum. Gate these separate `*V1_3` APIs with `doesChainSupportMultiAssetManagers()`. Use `creatorRevenueByToken()` and `withdrawCreatorRevenueByToken()` for current Ethereum fees, passing native ETH as `zeroAddress`; the unsuffixed revenue methods continue to use the legacy escrow. Current imported-token receipts preserve the pairing but have empty launch-metadata strings because the event does not emit that metadata.
 
 Static-split recipients independently divide 100% of the pool remaining after creator/owner allocation. This corrects previous Base behavior; callers must not pre-scale recipient percentages by the residual pool size. See the unreleased changelog and static-split tests before upgrading.
 
@@ -193,7 +197,7 @@ if (poolCreatedData) {
 
 ### Flaunching with a Paired Token
 
-Base, Base Sepolia, and Robinhood support the V1.3 paired-token launch path.
+Base, Base Sepolia, Robinhood and Ethereum support the V1.3-compatible paired-token launch path.
 The paired token must be approved by that chain's `PairedTokenRegistry`; use
 `zeroAddress` to select native ETH.
 
@@ -238,6 +242,11 @@ const hash = await flaunchWrite.flaunchPairedToken({
 The SDK does not auto-approve ERC20 spending or enforce a sponsorship policy.
 Applications that promise a gas-sponsored launch should reject unexpected
 non-zero quote values before signing, as the API service does.
+
+To attach a multi-asset manager, pass `treasuryManagerParams` to `flaunchPairedToken()`:
+`{ manager, permissions, initializeData, depositData }`. These are the on-chain address/bytes
+fields; use `getPermissionsAddressV1_3()` for the permissions address. An approved current
+implementation deploys a new manager; an existing current manager instance receives the launch NFT.
 
 #### How to generate `base64Image` from User uploaded file
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flaunch/sdk",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Flaunch SDK to easily interact with the Flaunch protocol",
   "license": "MIT",
   "author": "Apoorv Lathey <apoorv@flayer.io>",

--- a/src/abi/AnyPositionManagerV1_3.ts
+++ b/src/abi/AnyPositionManagerV1_3.ts
@@ -1,0 +1,28 @@
+/** Current imported-token PoolCreated event (the paired token was added in V1.3). */
+export const AnyPositionManagerV1_3Abi = [
+  {
+    type: "event",
+    name: "PoolCreated",
+    inputs: [
+      { name: "_poolId", type: "bytes32", indexed: true },
+      { name: "_memecoin", type: "address", indexed: false },
+      { name: "_memecoinTreasury", type: "address", indexed: false },
+      { name: "_tokenId", type: "uint256", indexed: false },
+      { name: "_currencyFlipped", type: "bool", indexed: false },
+      {
+        name: "_params",
+        type: "tuple",
+        indexed: false,
+        components: [
+          { name: "memecoin", type: "address" },
+          { name: "creator", type: "address" },
+          { name: "creatorFeeAllocation", type: "uint24" },
+          { name: "initialPriceParams", type: "bytes" },
+          { name: "feeCalculatorParams", type: "bytes" },
+          { name: "pairedToken", type: "address" },
+        ],
+      },
+    ],
+    anonymous: false,
+  },
+] as const;

--- a/src/abi/FlaunchPositionManagerV1_3.ts
+++ b/src/abi/FlaunchPositionManagerV1_3.ts
@@ -9,6 +9,13 @@ import { FlaunchParamsV1_3Components } from "./FlaunchParamsV1_3";
 export const FlaunchPositionManagerV1_3Abi = [
   {
     type: "function",
+    name: "flaunchContract",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
     name: "poolKey",
     inputs: [{ name: "_token", type: "address", internalType: "address" }],
     outputs: [

--- a/src/abi/FlaunchZapV1_3.ts
+++ b/src/abi/FlaunchZapV1_3.ts
@@ -1,6 +1,9 @@
 import { FlaunchParamsV1_3Components } from "./FlaunchParamsV1_3";
 
-/** Minimal paired-token launch interface without treasury-manager overloads. */
+/**
+ * Paired-token launches with an explicit premine cap. Keep the plain overload first:
+ * Drift breaks ties by ABI order when both overloads match the three plain named arguments.
+ */
 export const FlaunchZapV1_3Abi = [
   {
     type: "function",
@@ -34,6 +37,35 @@ export const FlaunchZapV1_3Abi = [
         internalType: "struct IPositionManager.FlaunchParams",
         components: FlaunchParamsV1_3Components,
       },
+      { name: "_trustedFeeSigner", type: "address" },
+      { name: "_maxPremineCost", type: "uint256" },
+    ],
+    outputs: [
+      { name: "memecoin_", type: "address" },
+      { name: "ethSpent_", type: "uint256" },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "flaunch",
+    inputs: [
+      {
+        name: "_flaunchParams",
+        type: "tuple",
+        internalType: "struct IPositionManager.FlaunchParams",
+        components: FlaunchParamsV1_3Components,
+      },
+      {
+        name: "_treasuryManagerParams",
+        type: "tuple",
+        components: [
+          { name: "manager", type: "address" },
+          { name: "permissions", type: "address" },
+          { name: "initializeData", type: "bytes" },
+          { name: "depositData", type: "bytes" },
+        ],
+      },
       {
         name: "_trustedFeeSigner",
         type: "address",
@@ -48,6 +80,7 @@ export const FlaunchZapV1_3Abi = [
     outputs: [
       { name: "memecoin_", type: "address", internalType: "address" },
       { name: "ethSpent_", type: "uint256", internalType: "uint256" },
+      { name: "deployedManager_", type: "address" },
     ],
     stateMutability: "payable",
   },

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -15,6 +15,7 @@ export * from "./FlaunchPositionManager";
 export * from "./FlaunchPositionManagerV1_0";
 export * from "./FlaunchPositionManagerV1_1";
 export * from "./FlaunchPositionManagerV1_3";
+export * from "./AnyPositionManagerV1_3";
 export * from "./FlaunchV1_1";
 export * from "./FlaunchZap";
 export * from "./FlaunchManagerZapV1_3";

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -20,6 +20,7 @@ export const FlaunchZapAddress: Addresses = {
 // launch into the manager IMPLEMENTATION, stranding the launch NFT — never point a manager launch
 // at one. Base Sepolia's zap is still factory-less.
 export const FlaunchZapV1_3Address: Addresses = {
+  [mainnet.id]: "0x11666704fcd96e1CAFF9b99501FA1e79D64900fC", // v1.4.0, factory-bound, 2026-09-11
   [base.id]: "0xf787d757674b21efd713fb636b16ed994bfa82a8",
   [baseSepolia.id]: "0x0c560537301396683c150eade42277a04b96e6d8", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202); bound to factory 0x98dfdd0A…
   [robinhood.id]: "0x740f8278Fd9C548fF50b64805337eA8Ad24b2553",
@@ -63,6 +64,7 @@ export const FlaunchPositionManagerV1_2Address: Addresses = {
 // (fresh post-#285 InternalSwapPool; same registry / escrow / factory as v1.3.1). Robinhood's
 // superseded v1.3.1 hooks still serve their pools — see SupersededPositionManagerV1_3Address.
 export const FlaunchPositionManagerV1_3Address: Addresses = {
+  [mainnet.id]: "0xb741a710E456FC6d7f76c88F5C56B27D05e8A5DC", // v1.4.0 (same paired-token ABI family)
   [base.id]: "0x588c683ecc450f8b2aadb13d7f63792b840425dc",
   [baseSepolia.id]: "0x8d346f24278c5cd786309161aac0fc2bbe4c25dc", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0x8D346f24278C5CD786309161aAC0fC2bbe4c25dc",
@@ -89,12 +91,14 @@ export const SupersededPositionManagerV1_3Address: Record<number, Address[]> = {
 // PositionManagers used by the paired-token launch path. This is separate from
 // FlaunchPositionManagerV1_3Address because that map also drives version routing.
 export const PairedTokenPositionManagerV1_3Address: Addresses = {
+  [mainnet.id]: "0xb741a710E456FC6d7f76c88F5C56B27D05e8A5DC",
   [base.id]: "0x588c683ecc450f8b2aadb13d7f63792b840425dc",
   [baseSepolia.id]: "0x8d346f24278c5cd786309161aac0fc2bbe4c25dc", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0x8D346f24278C5CD786309161aAC0fC2bbe4c25dc",
 };
 
 export const PairedTokenRegistryV1_3Address: Addresses = {
+  [mainnet.id]: "0xFc28B339376018727eFcD45fdb257D0A0861A391",
   [base.id]: "0x26958422636655b5a4eCE23a062e2EB61332c6da",
   [baseSepolia.id]: "0x23cb441d18ca75c6a14964b06806df668d45a1c6",
   [robinhood.id]: "0xC3F4E72DE4D37988F12C101b0766Fd8462F6Faf9",
@@ -111,6 +115,7 @@ export const PairedTokenRegistryV1_3Address: Addresses = {
 // v1.3.3). `PoolSwapForHookV1_3Address` maps each hook to the router its gate approves; use
 // `poolSwapForHook(chainId, hook)` from `helpers`.
 export const PoolSwapV1_3Address: Addresses = {
+  [mainnet.id]: "0x05c6C717B2a985809a83D27F779044c2da27fd56", // Protected API v1, v1.4.0
   [base.id]: "0x1B8065a099AdcD7aa7c5e241e3596B56ec98bA5a", // Protected API v1 (v1.3.4), deployed 2026-09-08 @ 51035669, Basescan-verified
   [baseSepolia.id]: "0xb32a99502f433f78454a4d20304e654cdda75c5c", // Protected API v1; verified and gate-approved 2026-09-07
   [robinhood.id]: "0xD33dD3B3Aea607F2cC38cdd154eF5d48847Aa764", // Protected API v1 (v1.3.4), deployed 2026-09-08 @ 57595126, Sourcify exact match
@@ -118,6 +123,10 @@ export const PoolSwapV1_3Address: Addresses = {
 
 /** Hook (lowercase) → the PoolSwap approved on that hook generation's spend gate. */
 export const PoolSwapForHookV1_3Address: Record<number, Record<string, Address>> = {
+  [mainnet.id]: {
+    "0xb741a710e456fc6d7f76c88f5c56b27d05e8a5dc": "0x05c6C717B2a985809a83D27F779044c2da27fd56",
+    "0x0215c3ef94ef3e86c32e847c662ad649000965dc": "0x05c6C717B2a985809a83D27F779044c2da27fd56",
+  },
   [base.id]: {
     "0x588c683ecc450f8b2aadb13d7f63792b840425dc": "0x1B8065a099AdcD7aa7c5e241e3596B56ec98bA5a", // v1.3.1 PM, gate 0xBdbF…
   },
@@ -195,6 +204,7 @@ export const AnyPositionManagerAddress: Addresses = {
 
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyPositionManagerV1_3Address: Addresses = {
+  [mainnet.id]: "0x0215C3ef94ef3e86c32e847c662ad649000965Dc",
   [base.id]: "0x6ea0edee449a287504990df8d87951b9436825dc",
   [baseSepolia.id]: "0x9abfbdc34a294de5210c0889f21d5af54c4965dc", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0x9AbfbDc34A294De5210C0889f21D5Af54C4965DC",
@@ -217,6 +227,7 @@ export const FlaunchV1_2Address: Addresses = {
 
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const FlaunchV1_3Address: Addresses = {
+  [mainnet.id]: "0x393a09033Bf60cF67809d6D8b77C1254f39d2FF9",
   [base.id]: "0x475a09618bfd00fa4cb03b8504e95b62075e6f7d",
   [baseSepolia.id]: "0xc17a8523290ea839b4c1ddef121d8736a06f5623", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0x373c037C90a681079c3343ddAFCEEa8d9D8DE96E",
@@ -229,6 +240,7 @@ export const AnyFlaunchAddress: Addresses = {
 
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyFlaunchV1_3Address: Addresses = {
+  [mainnet.id]: "0x154f2E2ef6fAdFFe6bCF4d86a2639A6Ef4981c5C",
   [base.id]: "0x299c7e6992a4630d77a8cbd60aa78e17189e53f7",
   [baseSepolia.id]: "0x2154c604df568a5285284d1c4918dc98c39240df", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0x1bbbD15A6D5176edc7B42f2cc6cA800D9d74015D",
@@ -258,6 +270,7 @@ export const BidWallV1_1Address: Addresses = {
 
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const BidWallV1_3Address: Addresses = {
+  [mainnet.id]: "0xE02e0C934969647E0099Cb231BBC6BBCe1b91dF6",
   [base.id]: "0x0dae90b70f62ce3b1d5278f4763bd1f595d6a687",
   [baseSepolia.id]: "0xdedfd72f5e0555bd21e3c3d94297dee2a435b366", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0xB95ad380B6C2F39b67d8582Eb198ba3881Aa06D4",
@@ -270,6 +283,7 @@ export const AnyBidWallAddress: Addresses = {
 
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const AnyBidWallV1_3Address: Addresses = {
+  [mainnet.id]: "0xE1eBcD62AEBd327A4c22dB9e68A8E81119a7eABF",
   [base.id]: "0x9d58ca8011096ad711babf0d990c45b9d5bb047d",
   [baseSepolia.id]: "0x4c8a5c0fe00448c5bbbd0d7aec95c9ef3b81262b", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0xf32316145caf0A381FA587A7CE1bf850d58Af3aC",
@@ -323,42 +337,49 @@ export const BuyBackManagerAddress: Addresses = {
 // and zap, paying out per payout asset (ETH = address(0), or the coin's paired token). Managers
 // deployed from the old factory keep working through the unsuffixed APIs.
 export const TreasuryManagerFactoryV1_3Address: Addresses = {
+  [mainnet.id]: "0xD2B91d92AF59b7BEd15b5458feCF0e87C8A7c21e",
   [base.id]: "0xB03Be6c735ef90189D6a22bBC8F6A45a33348fDe",
   [baseSepolia.id]: "0x98dfdd0aac46c85fa35d67941d394019b7e3a18d", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0xE1eBcD62AEBd327A4c22dB9e68A8E81119a7eABF",
 };
 
 export const RevenueManagerV1_3Address: Addresses = {
+  [mainnet.id]: "0xf2947840eeA730f9E9ECC6559526392d68e89569",
   [base.id]: "0x908D692E628073A5B644Bc32B8dF57A5d1842288",
   [baseSepolia.id]: "0x0cf6bdf0a85a9d6763361037985b76c8893553af", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0xFc28B339376018727eFcD45fdb257D0A0861A391",
 };
 
 export const AddressFeeSplitManagerV1_3Address: Addresses = {
+  [mainnet.id]: "0x740f8278Fd9C548fF50b64805337eA8Ad24b2553",
   [base.id]: "0x7dC776cf57DacA91b315fe4F8803577dAb560ba5",
   [baseSepolia.id]: "0x7397390360bd9d559d9277e60d47b99933791232", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0x7dc0f14204841e0314eB0265a0c420995F200243",
 };
 
 export const DynamicAddressFeeSplitManagerV1_3Address: Addresses = {
+  [mainnet.id]: "0x0f03Aa8d303Ee15ed3Be81Bf43c41EFfFa4a7a5B",
   [base.id]: "0xC4a0B79A0dB1F7F67da97E7F9A8867B6CaF017b2",
   [baseSepolia.id]: "0xd37aee3edebf59f149b5d3b29b6ad2239f8a6b00", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0x1969bcF2779D53FeEA95480a7ab79f7cEfeE1681",
 };
 
 export const ERC721OwnerFeeSplitManagerV1_3Address: Addresses = {
+  [mainnet.id]: "0x43ff2F15A821C24A0576Fc376B789846080F2F0f",
   [base.id]: "0xDbFA9d3cab72EAE6Ba44ebC27175706aA451d9c0",
   [baseSepolia.id]: "0xce84bdd578c60e98e79a3a05392010b443ddaa9e", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0x51BdE7C1e2Ea54949C015F4f3ED3CAE185543C0b",
 };
 
 export const StakingManagerV1_3Address: Addresses = {
+  [mainnet.id]: "0xEf8be05d08fbCBFB89bAa05fA7a56BD818Ca9181",
   [base.id]: "0x72b9192017361eA00cDc1Cf1AC0F178cf89920cA",
   [baseSepolia.id]: "0x4d5616c04e59ce47b40e54c1d106363da74c1a2e", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0xd992F465d55B005E8D2Aff9fcE977Cb78f5652e0",
 };
 
 export const GroupMapperV1_3Address: Addresses = {
+  [mainnet.id]: "0x3F7C69F516238FEC37CF06Fde0B95BD37B2B531D",
   [base.id]: "0x4a68638179De37163d86B10e6B4b927CA1a0dE87",
   [baseSepolia.id]: "0x41964dd84f25cd5830f5c4deeb54efab3ed7e087", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0xBdbF379f9EdFB5993FC00b41AAEfeE8475eAC0Ac",
@@ -367,6 +388,7 @@ export const GroupMapperV1_3Address: Addresses = {
 // Deploys + initializes a v1.3.1 manager through the v1.3.1 factory in one call. Launching a coin
 // straight into a manager stays with the core FlaunchZap.
 export const FlaunchManagerZapV1_3Address: Addresses = {
+  [mainnet.id]: "0xf7579C3cb8607F6CE00311465d28Ac45666f39Ad",
   [base.id]: "0xD7E0c1D2B2a588cEC3b2Bdc9428FfE59b739749B",
   [baseSepolia.id]: "0xf175a370eb26ea26c42caaecd10ee723ed844c50", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0xAf037090FF86EFdc8d4ba82728aC93042ad1EC73",
@@ -382,6 +404,7 @@ export const TokenImporterAddress: Addresses = {
 // previous generation's importer (Base's 0x6fb66f4f… is being retired) and is left untouched for
 // callers importing into the old hooks.
 export const TokenImporterV1_3Address: Addresses = {
+  [mainnet.id]: "0x319A17b4D6529107FC9a8312371f3C74D4083e5e",
   [base.id]: "0xea78c26690b5a0dde2a5a8db7760b5da79bfd76e",
   [baseSepolia.id]: "0xc65fc67fa953869df97ab2dba96fa58f2bdc9891", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0xf7579C3cb8607F6CE00311465d28Ac45666f39Ad",
@@ -440,9 +463,15 @@ export const WhitelistedPermissionsAddress: Addresses = {
 // WhitelistedPermissions validates a group against the factory it was built with, so managers
 // from the v1.3.1 factory need this instance. ClosedPermissions is factory-agnostic and reused.
 export const WhitelistedPermissionsV1_3Address: Addresses = {
+  [mainnet.id]: "0x4765Ea884Bc29219eCC430F2C478d4f646071d78",
   [base.id]: "0xaCE028CB08A19C4d2a6e442516EbA7d114C09Af9",
   [baseSepolia.id]: "0xbe6245b2c8d59618a080bd5b2d67b3c813a9ab7c", // Base Sepolia v1.3.1 managers, 2026-09-03 (blocks 46348872–46348885)
   [robinhood.id]: "0xF772256B811D2241488d3d659E9cf797B387eFC3",
+};
+
+export const ClosedPermissionsV1_3Address: Addresses = {
+  ...ClosedPermissionsAddress,
+  [mainnet.id]: "0x00BD5d089626F84E0DfF241D5e71336Add6D4bF3",
 };
 /** =========== */
 
@@ -459,6 +488,7 @@ export const FeeEscrowAddress: Addresses = {
 // `.vpt2` deployment (flaunch-contracts deployments/base-sepolia.md); Robinhood from
 // deployments/robinhood-mainnet.md.
 export const FeeEscrowV1_3Address: Addresses = {
+  [mainnet.id]: "0xd992F465d55B005E8D2Aff9fcE977Cb78f5652e0",
   [base.id]: "0x17fbf54d6d15ebff82eee77e616f701952d08bb4",
   [baseSepolia.id]: "0xf4af7b459e971d9757c2100c626199c6c6334fca",
   [robinhood.id]: "0x4fb9de6bbe970a49c19fb967f937351728c01b8f",
@@ -471,6 +501,7 @@ export const ReferralEscrowAddress: Addresses = {
 
 // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663); no baseSepolia deployment
 export const ReferralEscrowV1_3Address: Addresses = {
+  [mainnet.id]: "0x2FAde59484677FE39144D6d1B74aE57E8E424595",
   [base.id]: "0xe86bfebc4f094d36074833618779d279a9af01aa",
   [baseSepolia.id]: "0x7c6088c1185fbb770deb1ca7ddeed4ba57659663", // Base Sepolia v1.3.3 regeneration, 2026-09-03 (blocks 46349133–46349202)
   [robinhood.id]: "0xB9827C0c7Cb61be4D58700B114E34D8448889eD8",
@@ -482,6 +513,12 @@ export const FLETHAddress: Addresses = {
   [mainnet.id]: "0x000000000bB1f9944965c64066D10038a84F9af2",
   [unichain.id]: "0x000000000DD39073Cfc60e7102288ccBd7Bf23fE",
   [robinhood.id]: "0x00000000043C1117DAFA3A3D0C7148Eb48B30130",
+};
+
+/** Default pairing for new launches. FLETHAddress remains available for legacy pools. */
+export const DefaultPairedTokenAddress: Addresses = {
+  ...FLETHAddress,
+  [mainnet.id]: zeroAddress,
 };
 
 type FreshChainNativeETHSwapConfig = {
@@ -572,6 +609,7 @@ export const UniversalRouterAddress: Addresses = {
 };
 
 export const QuoterAddress: Addresses = {
+  [mainnet.id]: "0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203",
   [base.id]: "0x0d5e0f971ed27fbff6c2837bf31316121532048d",
   [baseSepolia.id]: "0x4a6513c898fe1b2d0e78d3b0e0a4a151589b1cba",
   ...freshChainNativeETHSwapAddresses("quoter"),
@@ -586,6 +624,7 @@ export const StateViewAddress: Addresses = {
 };
 
 export const Permit2Address: Addresses = {
+  [mainnet.id]: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
   [base.id]: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
   [baseSepolia.id]: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
   ...freshChainNativeETHSwapAddresses("permit2"),

--- a/src/clients/FlaunchZapMultichainClient.ts
+++ b/src/clients/FlaunchZapMultichainClient.ts
@@ -17,10 +17,15 @@ import {
 import { FlaunchZapAbi } from "../abi/FlaunchZap";
 import {
   AddressFeeSplitManagerAddress,
+  AddressFeeSplitManagerV1_3Address,
+  DefaultPairedTokenAddress,
   DynamicAddressFeeSplitManagerAddress,
+  DynamicAddressFeeSplitManagerV1_3Address,
+  FlaunchZapV1_3Address,
 } from "../addresses";
 import { generateTokenUri } from "../helpers/ipfs";
-import { getPermissionsAddress } from "../helpers/permissions";
+import { getPermissionsAddress, getPermissionsAddressV1_3 } from "../helpers/permissions";
+import { ReadWriteFlaunchZapV1_3 } from "./FlaunchZapV1_3Client";
 import { Permissions } from "../types";
 import type {
   FlaunchIPFSParams,
@@ -114,7 +119,7 @@ export class ReadWriteFlaunchZapMultichain extends ReadFlaunchZapMultichain {
 
   constructor(
     address: Address,
-    drift: Drift<ReadWriteAdapter> = createDrift()
+    private readonly drift: Drift<ReadWriteAdapter> = createDrift()
   ) {
     super(address, drift);
   }
@@ -130,8 +135,32 @@ export class ReadWriteFlaunchZapMultichain extends ReadFlaunchZapMultichain {
    */
   async flaunch(chainId: number, params: FlaunchParams) {
     const flaunchParams = this.prepareFlaunch(params);
-    const ethRequired = await this.calculateFee(flaunchParams);
     const manager = params.treasuryManagerParams?.manager;
+
+    // Ethereum's current generation defaults to native ETH. Keep the legacy client and
+    // address maps intact for existing pools while new launches use the paired-token ABI.
+    if (DefaultPairedTokenAddress[chainId] === zeroAddress) {
+      const zap = new ReadWriteFlaunchZapV1_3(FlaunchZapV1_3Address[chainId], this.drift);
+      const pairedParams = { ...flaunchParams, pairedToken: zeroAddress };
+      const fee = await zap.calculateFee({ flaunchParams: pairedParams, slippageBps: 500n });
+      return zap.flaunch({
+        flaunchParams: pairedParams,
+        trustedFeeSigner: zeroAddress,
+        maxPremineCost: fee.pairedPremineCost,
+        value: fee.ethRequired,
+        treasuryManagerParams: manager ? {
+          manager,
+          permissions: getPermissionsAddressV1_3(
+            params.treasuryManagerParams?.permissions ?? Permissions.OPEN,
+            chainId
+          ),
+          initializeData: params.treasuryManagerParams?.initializeData ?? "0x",
+          depositData: params.treasuryManagerParams?.depositData ?? "0x",
+        } : undefined,
+      });
+    }
+
+    const ethRequired = await this.calculateFee(flaunchParams);
 
     if (!manager) {
       return this.contract.write(
@@ -231,7 +260,9 @@ export class ReadWriteFlaunchZapMultichain extends ReadFlaunchZapMultichain {
     return this.flaunch(chainId, {
       ...params,
       treasuryManagerParams: {
-        manager: AddressFeeSplitManagerAddress[chainId],
+        manager: DefaultPairedTokenAddress[chainId] === zeroAddress
+          ? AddressFeeSplitManagerV1_3Address[chainId]
+          : AddressFeeSplitManagerAddress[chainId],
         permissions:
           params.treasuryManagerParams?.permissions ?? Permissions.OPEN,
         initializeData,
@@ -344,25 +375,16 @@ export class ReadWriteFlaunchZapMultichain extends ReadFlaunchZapMultichain {
       ]
     );
 
-    const flaunchParams = this.prepareFlaunch(params);
-    const ethRequired = await this.calculateFee(flaunchParams);
-
-    return this.contract.write(
-      "flaunch",
-      {
-        _flaunchParams: flaunchParams,
-        _treasuryManagerParams: {
-          manager: DynamicAddressFeeSplitManagerAddress[chainId],
-          permissions: getPermissionsAddress(
-            params.treasuryManagerParams?.permissions ?? Permissions.OPEN,
-            chainId
-          ),
-          initializeData,
-          depositData: "0x",
-        },
-        _trustedFeeSigner: zeroAddress,
+    return this.flaunch(chainId, {
+      ...params,
+      treasuryManagerParams: {
+        manager: DefaultPairedTokenAddress[chainId] === zeroAddress
+          ? DynamicAddressFeeSplitManagerV1_3Address[chainId]
+          : DynamicAddressFeeSplitManagerAddress[chainId],
+        permissions: params.treasuryManagerParams?.permissions ?? Permissions.OPEN,
+        initializeData,
+        depositData: "0x",
       },
-      { value: ethRequired }
-    );
+    });
   }
 }

--- a/src/clients/FlaunchZapV1_3Client.ts
+++ b/src/clients/FlaunchZapV1_3Client.ts
@@ -36,6 +36,13 @@ export type CalculatePairedTokenFlaunchFeeParams = {
 
 export type FlaunchPairedTokenParams = {
   flaunchParams: PairedTokenFlaunchParams;
+  /** An approved implementation deploys a manager; an instance receives the launch NFT. */
+  treasuryManagerParams?: {
+    manager: Address;
+    permissions: Address;
+    initializeData: HexString;
+    depositData: HexString;
+  };
   trustedFeeSigner: Address;
   maxPremineCost: bigint;
   value: bigint;
@@ -83,10 +90,24 @@ export class ReadWriteFlaunchZapV1_3 extends ReadFlaunchZapV1_3 {
 
   flaunch({
     flaunchParams,
+    treasuryManagerParams,
     trustedFeeSigner,
     maxPremineCost,
     value,
   }: FlaunchPairedTokenParams) {
+    if (treasuryManagerParams) {
+      return this.contract.write(
+        "flaunch",
+        {
+          _flaunchParams: flaunchParams,
+          _treasuryManagerParams: treasuryManagerParams,
+          _trustedFeeSigner: trustedFeeSigner,
+          _maxPremineCost: maxPremineCost,
+        },
+        { value }
+      );
+    }
+
     return this.contract.write(
       "flaunch",
       {

--- a/src/clients/QuoterClient.ts
+++ b/src/clients/QuoterClient.ts
@@ -9,8 +9,9 @@ import {
   createDrift,
 } from "@delvtech/drift";
 import { QuoterAbi } from "../abi/Quoter";
-import { encodeFunctionData, decodeFunctionResult, formatUnits, parseEther, zeroAddress } from "viem";
-import { FLETHAddress, FLETHHooksAddress, USDCETHPoolKeys } from "addresses";
+import { encodeAbiParameters, encodeFunctionData, decodeFunctionResult, formatUnits, parseEther, zeroAddress } from "viem";
+import { DefaultPairedTokenAddress, FLETHAddress, FLETHHooksAddress, FlaunchPositionManagerV1_3Address, USDCETHPoolKeys } from "addresses";
+import { ReadFlaunchPositionManagerV1_2 } from "./FlaunchPositionManagerV1_2Client";
 import { PoolKey, PoolWithHookData } from "types";
 
 export type QuoterABI = typeof QuoterAbi;
@@ -435,6 +436,15 @@ export class ReadQuoter {
    * @returns Promise<number> - The price of 1 ETH in USDC, formatted with 2 decimal places
    */
   async getETHUSDCPrice() {
+    if (DefaultPairedTokenAddress[this.chainId] === zeroAddress) {
+      // The mainnet launch oracle converts a 6-decimal USD market cap into ETH wei
+      // using its 30-minute WETH/USDC V3 TWAP. Invert that conversion for USD per ETH.
+      const marketCapInETH = await new ReadFlaunchPositionManagerV1_2(
+        FlaunchPositionManagerV1_3Address[this.chainId], this.quoteDrift
+      ).getFlaunchingMarketCap(encodeAbiParameters([{ type: "uint256" }], [10_000_000_000n]));
+      return Number((10_000 / Number(formatUnits(marketCapInETH, 18))).toFixed(2));
+    }
+
     const amountIn = parseEther("1");
 
     const res = await this.contract.simulateWrite("quoteExactInput", {

--- a/src/helpers/permissions.ts
+++ b/src/helpers/permissions.ts
@@ -2,6 +2,7 @@ import { Address, zeroAddress } from "viem";
 import { Permissions } from "../types";
 import {
   ClosedPermissionsAddress,
+  ClosedPermissionsV1_3Address,
   WhitelistedPermissionsAddress,
   WhitelistedPermissionsV1_3Address,
 } from "../addresses";
@@ -42,7 +43,7 @@ export function getPermissionsAddressV1_3(
 ): Address {
   switch (permissions) {
     case Permissions.CLOSED:
-      return ClosedPermissionsAddress[chainId];
+      return ClosedPermissionsV1_3Address[chainId];
     case Permissions.WHITELISTED:
       return WhitelistedPermissionsV1_3Address[chainId];
     case Permissions.OPEN:

--- a/src/helpers/supportedChains.ts
+++ b/src/helpers/supportedChains.ts
@@ -7,6 +7,7 @@ import {
 import { chainIdToChain } from "./chainIdToChain";
 import {
   DynamicAddressFeeSplitManagerAddress,
+  AnyPositionManagerV1_3Address,
   FeeEscrowV1_3Address,
   FlaunchManagerZapV1_3Address,
   TreasuryManagerFactoryV1_3Address,
@@ -86,8 +87,10 @@ export function doesChainSupportPairedTokenLaunch(chainId: number): boolean {
  */
 export function getV1_3PositionManagers(chainId: number): Address[] {
   const current = PairedTokenPositionManagerV1_3Address[chainId];
+  const any = AnyPositionManagerV1_3Address[chainId];
   return [
     ...(current ? [current] : []),
+    ...(any ? [any] : []),
     ...(SupersededPositionManagerV1_3Address[chainId] ?? []),
   ];
 }

--- a/src/sdk/FlaunchSDK.ts
+++ b/src/sdk/FlaunchSDK.ts
@@ -42,6 +42,7 @@ import {
   StateViewAddress,
   PoolManagerAddress,
   FLETHAddress,
+  DefaultPairedTokenAddress,
   FairLaunchAddress,
   FlaunchZapAddress,
   FlaunchAddress,
@@ -55,6 +56,8 @@ import {
   FairLaunchV1_1Address,
   TreasuryManagerFactoryAddress,
   AnyPositionManagerAddress,
+  AnyPositionManagerV1_3Address,
+  AnyFlaunchV1_3Address,
   AnyBidWallAddress,
   AnyFlaunchAddress,
   FeeEscrowAddress,
@@ -68,7 +71,6 @@ import {
   FlaunchV1_2Address,
   // v1.3.1 (GitHub release v1.3.1) - Base mainnet + Robinhood (4663)
   FlaunchPositionManagerV1_3Address,
-  SupersededPositionManagerV1_3Address,
   FlaunchZapV1_3Address,
   PairedTokenPositionManagerV1_3Address,
   PairedTokenRegistryV1_3Address,
@@ -76,6 +78,7 @@ import {
   FlaunchV1_3Address,
   BidWallV1_3Address,
   FlaunchPositionManagerMultichainAddress,
+  FlaunchMultichainAddress,
   FlaunchZapMultichainAddress,
   // V1.2 and AnyPositionManager addresses will be imported here when available
   PoolSwapForHookV1_3Address,
@@ -208,6 +211,7 @@ import {
 import { UniversalRouterAbi } from "abi/UniversalRouter";
 import { FlaunchPositionManagerV1_2Abi } from "abi/FlaunchPositionManagerV1_2";
 import { FlaunchPositionManagerV1_3Abi } from "abi/FlaunchPositionManagerV1_3";
+import { AnyPositionManagerV1_3Abi } from "abi/AnyPositionManagerV1_3";
 import { FlaunchPositionManagerAbi } from "abi/FlaunchPositionManager";
 import {
   CallWithDescription,
@@ -733,6 +737,9 @@ export class ReadFlaunchSDK {
     return this.getBaseClient("readPoolManager");
   }
   get readStateView() {
+    if (DefaultPairedTokenAddress[this.chainId] === zeroAddress && this.pairedSwapStateView) {
+      return this.pairedSwapStateView;
+    }
     return this.getBaseClient("readStateView");
   }
   get readFairLaunch() {
@@ -1005,13 +1012,10 @@ export class ReadFlaunchSDK {
       }
     };
 
-    let result: { hook: Address; version: FlaunchVersion } | null = null;
-    for (const hook of getV1_3PositionManagers(this.chainId)) {
-      if (await isValidOn(hook)) {
-        result = { hook, version: FlaunchVersion.V1_3 };
-        break;
-      }
-    }
+    const pairedPool = await this.locatePairedPool(coinAddress);
+    let result: { hook: Address; version: FlaunchVersion } | null = pairedPool
+      ? { hook: pairedPool.hook, version: FlaunchVersion.V1_3 }
+      : null;
     if (!result) {
       const multichainHook = FlaunchPositionManagerMultichainAddress[this.chainId];
       if (multichainHook && (await isValidOn(multichainHook))) {
@@ -1059,6 +1063,17 @@ export class ReadFlaunchSDK {
     }
   }
 
+  protected assertLegacyETHSwapHook(hook: Address) {
+    if (
+      DefaultPairedTokenAddress[this.chainId] === zeroAddress &&
+      getV1_3PositionManagers(this.chainId).some((current) => isAddressEqual(current, hook))
+    ) {
+      throw new Error(
+        "This pool requires the protected paired-token swap API: use quotePairedPool or planPairedTokenSwap"
+      );
+    }
+  }
+
   /** The paired-token PositionManager client for a given hook address, memoised per hook. */
   protected pairedTokenPositionManagerAt(hook: Address): ReadPairedTokenPositionManagerV1_3 {
     const key = hook.toLowerCase();
@@ -1096,7 +1111,7 @@ export class ReadFlaunchSDK {
       } catch {
         continue;
       }
-      if (isEmptyPoolKey(poolKey)) continue;
+      if (poolKey.tickSpacing === 0 || isEmptyPoolKey(poolKey)) continue;
       const located = { hook, poolKey };
       this.pairedPoolsByCoin.set(key, located);
       return located;
@@ -1731,6 +1746,16 @@ export class ReadFlaunchSDK {
    * @param version - The version to get the flaunch contract instance for
    */
   getFlaunch(version: FlaunchVersion) {
+    if (isMultichainDeployment(this.chainId)) {
+      if (version === FlaunchVersion.V1_3 && FlaunchV1_3Address[this.chainId]) {
+        return new ReadFlaunchV1_2(FlaunchV1_3Address[this.chainId], this.drift);
+      }
+      if (version === FlaunchVersion.ANY && AnyFlaunchV1_3Address[this.chainId]) {
+        return new ReadAnyFlaunch(AnyFlaunchV1_3Address[this.chainId], this.drift);
+      }
+      return new ReadFlaunchV1_2(FlaunchMultichainAddress[this.chainId], this.drift);
+    }
+
     switch (version) {
       case FlaunchVersion.V1:
         return this.readFlaunch;
@@ -1757,6 +1782,12 @@ export class ReadFlaunchSDK {
 
   getPositionManagerAddress(version: FlaunchVersion) {
     if (isMultichainDeployment(this.chainId)) {
+      if (version === FlaunchVersion.V1_3 && FlaunchPositionManagerV1_3Address[this.chainId]) {
+        return FlaunchPositionManagerV1_3Address[this.chainId];
+      }
+      if (version === FlaunchVersion.ANY && AnyPositionManagerV1_3Address[this.chainId]) {
+        return AnyPositionManagerV1_3Address[this.chainId];
+      }
       return FlaunchPositionManagerMultichainAddress[this.chainId];
     }
     return this.getPositionManager(version).contract.address;
@@ -1778,6 +1809,14 @@ export class ReadFlaunchSDK {
   async getFlaunchTokenIdForMemecoin(
     coinAddress: Address
   ): Promise<{ flaunchAddress: Address; tokenId: bigint }> {
+    const pairedPool = await this.locatePairedPool(coinAddress);
+    if (pairedPool) {
+      const flaunchAddress = await this.pairedTokenPositionManagerAt(pairedPool.hook)
+        .contract.read("flaunchContract");
+      const tokenId = await new ReadFlaunchV1_2(flaunchAddress, this.drift).tokenId(coinAddress);
+      return { flaunchAddress, tokenId };
+    }
+
     const version = await this.getCoinVersion(coinAddress);
     const flaunch = this.getFlaunch(version);
     const tokenId = await flaunch.tokenId(coinAddress);
@@ -1999,14 +2038,9 @@ export class ReadFlaunchSDK {
 
   /** Parses PoolCreated from logs emitted by a PositionManager on this chain. */
   getPoolCreatedFromLogs(logs: readonly Log[]): PoolCreatedEventData | null {
-    const positionManagerV1_3 =
-      PairedTokenPositionManagerV1_3Address[this.chainId];
     // A chain can carry more than one v1.3 hook generation (Robinhood: the v1.3.1 hooks were
     // regenerated as v1.3.3); a receipt from either is a v1.3 PoolCreated.
-    const v1_3Hooks = [
-      ...(positionManagerV1_3 ? [positionManagerV1_3] : []),
-      ...(SupersededPositionManagerV1_3Address[this.chainId] ?? []),
-    ];
+    const v1_3Hooks = getV1_3PositionManagers(this.chainId);
 
     if (v1_3Hooks.length > 0) {
       for (const log of logs) {
@@ -2039,7 +2073,33 @@ export class ReadFlaunchSDK {
             };
           }
         } catch {
-          continue;
+          // Imported pools emit a smaller tuple, with no launch metadata or flaunch fee.
+          try {
+            const { args } = decodeEventLog({
+              abi: AnyPositionManagerV1_3Abi,
+              data: log.data,
+              topics: log.topics,
+            });
+            return {
+              poolId: args._poolId,
+              memecoin: args._memecoin,
+              memecoinTreasury: args._memecoinTreasury,
+              tokenId: args._tokenId,
+              currencyFlipped: args._currencyFlipped,
+              flaunchFee: 0n,
+              params: {
+                name: "", symbol: "", tokenUri: "",
+                initialTokenFairLaunch: 0n, premineAmount: 0n, flaunchAt: 0n,
+                creator: args._params.creator,
+                creatorFeeAllocation: Number(args._params.creatorFeeAllocation),
+                initialPriceParams: args._params.initialPriceParams,
+                feeCalculatorParams: args._params.feeCalculatorParams,
+                pairedToken: args._params.pairedToken,
+              },
+            };
+          } catch {
+            continue;
+          }
         }
       }
     }
@@ -2222,7 +2282,15 @@ export class ReadFlaunchSDK {
   async coinPriceInETH(coinAddress: Address, version?: FlaunchVersion) {
     const coinVersion = await this.determineCoinVersion(coinAddress, version);
 
-    const isFLETHZero = this.flETHIsCurrencyZero(coinAddress);
+    const pairedPool = DefaultPairedTokenAddress[this.chainId] === zeroAddress
+      ? await this.locatePairedPool(coinAddress) : null;
+    const pairedToken = pairedPool ? pairedTokenOfPoolKey(pairedPool.poolKey, coinAddress) : undefined;
+    if (pairedToken !== undefined && pairedToken !== zeroAddress) {
+      throw new Error("ERC20-paired coin prices require conversion from the paired token; use quotePairedPool");
+    }
+    const isFLETHZero = pairedPool
+      ? isAddressEqual(pairedPool.poolKey.currency0, zeroAddress)
+      : this.flETHIsCurrencyZero(coinAddress);
     const currentTick = await this.currentTick(coinAddress, coinVersion);
 
     const price = Math.pow(1.0001, currentTick);
@@ -2890,20 +2958,7 @@ export class ReadFlaunchSDK {
    * @returns Promise<string> - The pool ID
    */
   async poolId(coinAddress: Address, version?: FlaunchVersion) {
-    const hookAddress = await this.getPositionManagerAddressForCoin(
-      coinAddress,
-      version
-    );
-
-    return getPoolId(
-      orderPoolKey({
-        currency0: FLETHAddress[this.chainId],
-        currency1: coinAddress,
-        fee: 0,
-        tickSpacing: 60,
-        hooks: hookAddress,
-      })
-    );
+    return getPoolId(await this.createPoolKeyForCoin(coinAddress, version));
   }
 
   /**
@@ -2913,7 +2968,7 @@ export class ReadFlaunchSDK {
    * @param params.slippagePercent - The slippage percent
    * @returns Promise<bigint> - The flaunching fee
    */
-  getFlaunchingFee(params: {
+  async getFlaunchingFee(params: {
     sender: Address;
     initialMarketCapUSD: number;
     slippagePercent?: number;
@@ -2930,6 +2985,21 @@ export class ReadFlaunchSDK {
       ],
       [initialMCapInUSDCWei]
     );
+
+    if (DefaultPairedTokenAddress[this.chainId] === zeroAddress) {
+      const positionManager = new ReadFlaunchPositionManagerV1_2(
+        FlaunchPositionManagerV1_3Address[this.chainId], this.drift
+      );
+      const initialPrice = new ReadInitialPrice(
+        await positionManager.contract.read("initialPrice"), this.drift
+      );
+      const fee = await initialPrice.getFlaunchingFee({ sender: params.sender, initialPriceParams });
+      return getAmountWithSlippage({
+        amount: fee,
+        slippage: ((params.slippagePercent ?? 0) / 100).toFixed(18),
+        swapType: "EXACT_OUT",
+      });
+    }
 
     return this.readPositionManagerV1_1.getFlaunchingFee({
       sender: params.sender,
@@ -2962,6 +3032,18 @@ export class ReadFlaunchSDK {
       ],
       [initialMCapInUSDCWei]
     );
+
+    if (DefaultPairedTokenAddress[this.chainId] === zeroAddress) {
+      return this.calculatePairedTokenFlaunchFee({
+        flaunchParams: {
+          name: "", symbol: "", tokenUri: "",
+          premineAmount: params.premineAmount,
+          creator: zeroAddress, creatorFeeAllocation: 0, flaunchAt: 0n,
+          initialPriceParams, feeCalculatorParams: "0x", pairedToken: zeroAddress,
+        },
+        slippageBps: BigInt(Math.round((params.slippagePercent ?? 5) * 100)),
+      }).then((fee) => fee.ethRequired);
+    }
 
     return this.readFlaunchZap.ethRequiredToFlaunch({
       premineAmount: params.premineAmount,
@@ -3000,6 +3082,7 @@ export class ReadFlaunchSDK {
       version
     );
 
+    this.assertLegacyETHSwapHook(hookAddress);
     return this.readQuoter.getSellQuoteExactInput({
       coinAddress,
       amountIn,
@@ -3042,6 +3125,7 @@ export class ReadFlaunchSDK {
       version
     );
 
+    this.assertLegacyETHSwapHook(hookAddress);
     return this.readQuoter.getBuyQuoteExactInput({
       coinAddress,
       amountIn,
@@ -3084,6 +3168,7 @@ export class ReadFlaunchSDK {
       version
     );
 
+    this.assertLegacyETHSwapHook(hookAddress);
     return this.readQuoter.getBuyQuoteExactOutput({
       coinAddress,
       coinOut: amountOut,
@@ -3745,13 +3830,19 @@ export class ReadFlaunchSDK {
     coinAddress: Address,
     version?: FlaunchVersion
   ) {
+    const hook = await this.getPositionManagerAddressForCoin(coinAddress, version);
+    if (getV1_3PositionManagers(this.chainId).some((current) => isAddressEqual(current, hook))) {
+      const cached = this.pairedPoolsByCoin.get(coinAddress.toLowerCase());
+      if (cached && isAddressEqual(cached.hook, hook)) return cached.poolKey;
+      return this.pairedTokenPositionManagerAt(hook).poolKey(coinAddress);
+    }
     const flethAddress = FLETHAddress[this.chainId];
     return orderPoolKey({
       currency0: coinAddress,
       currency1: flethAddress,
       fee: 0,
       tickSpacing: this.TICK_SPACING,
-      hooks: await this.getPositionManagerAddressForCoin(coinAddress, version),
+      hooks: hook,
     });
   }
 }
@@ -4276,6 +4367,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
       params.coinAddress,
       version
     );
+    this.assertLegacyETHSwapHook(hookAddress);
 
     const sender = await this.drift.getSignerAddress();
 
@@ -4369,6 +4461,7 @@ export class ReadWriteFlaunchSDK extends ReadFlaunchSDK {
       params.coinAddress,
       version
     );
+    this.assertLegacyETHSwapHook(hookAddress);
 
     let amountOutMin: bigint;
 

--- a/test/ethereumV140.test.cjs
+++ b/test/ethereumV140.test.cjs
@@ -1,0 +1,195 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  decodeAbiParameters, decodeFunctionData, encodeAbiParameters,
+  encodeEventTopics, getAddress, parseAbi, zeroAddress,
+} = require("viem");
+const { base, baseSepolia, mainnet, robinhood, unichain } = require("viem/chains");
+const sdkExports = require("../dist/index.cjs.js");
+const {
+  AnyPositionManagerV1_3Address,
+  DefaultPairedTokenAddress, FLETHAddress, FlaunchVersion,
+  FlaunchZapV1_3Abi, FlaunchZapV1_3Address, PairedTokenPositionManagerV1_3Address,
+  Permissions, ReadFlaunchSDK, ReadWriteFlaunchSDK, getPermissionsAddressV1_3,
+  getPoolId, getV1_3PositionManagers, pairedPoolKey,
+} = sdkExports;
+
+// flaunch-contracts v1.4.0 deployments/ethereum-mainnet-2026-09-11.json;
+// deployed core 62c95ca2, managers 17e018f3. Legacy maps must remain separate.
+const RELEASE_ADDRESSES = {
+  FlaunchPositionManagerV1_3Address: "0xb741a710E456FC6d7f76c88F5C56B27D05e8A5DC",
+  PairedTokenPositionManagerV1_3Address: "0xb741a710E456FC6d7f76c88F5C56B27D05e8A5DC",
+  AnyPositionManagerV1_3Address: "0x0215C3ef94ef3e86c32e847c662ad649000965Dc",
+  FlaunchV1_3Address: "0x393a09033Bf60cF67809d6D8b77C1254f39d2FF9",
+  AnyFlaunchV1_3Address: "0x154f2E2ef6fAdFFe6bCF4d86a2639A6Ef4981c5C",
+  FlaunchZapV1_3Address: "0x11666704fcd96e1CAFF9b99501FA1e79D64900fC",
+  PoolSwapV1_3Address: "0x05c6C717B2a985809a83D27F779044c2da27fd56",
+  PairedTokenRegistryV1_3Address: "0xFc28B339376018727eFcD45fdb257D0A0861A391",
+  FeeEscrowV1_3Address: "0xd992F465d55B005E8D2Aff9fcE977Cb78f5652e0",
+  BidWallV1_3Address: "0xE02e0C934969647E0099Cb231BBC6BBCe1b91dF6",
+  AnyBidWallV1_3Address: "0xE1eBcD62AEBd327A4c22dB9e68A8E81119a7eABF",
+  ReferralEscrowV1_3Address: "0x2FAde59484677FE39144D6d1B74aE57E8E424595",
+  TokenImporterV1_3Address: "0x319A17b4D6529107FC9a8312371f3C74D4083e5e",
+  TreasuryManagerFactoryV1_3Address: "0xD2B91d92AF59b7BEd15b5458feCF0e87C8A7c21e",
+  RevenueManagerV1_3Address: "0xf2947840eeA730f9E9ECC6559526392d68e89569",
+  AddressFeeSplitManagerV1_3Address: "0x740f8278Fd9C548fF50b64805337eA8Ad24b2553",
+  DynamicAddressFeeSplitManagerV1_3Address: "0x0f03Aa8d303Ee15ed3Be81Bf43c41EFfFa4a7a5B",
+  ERC721OwnerFeeSplitManagerV1_3Address: "0x43ff2F15A821C24A0576Fc376B789846080F2F0f",
+  StakingManagerV1_3Address: "0xEf8be05d08fbCBFB89bAa05fA7a56BD818Ca9181",
+  GroupMapperV1_3Address: "0x3F7C69F516238FEC37CF06Fde0B95BD37B2B531D",
+  FlaunchManagerZapV1_3Address: "0xf7579C3cb8607F6CE00311465d28Ac45666f39Ad",
+  ClosedPermissionsV1_3Address: "0x00BD5d089626F84E0DfF241D5e71336Add6D4bF3",
+  WhitelistedPermissionsV1_3Address: "0x4765Ea884Bc29219eCC430F2C478d4f646071d78",
+};
+const COIN = "0xf000000000000000000000000000000000000001";
+const CREATOR = "0x1111111111111111111111111111111111111111";
+const TREASURY = "0x2222222222222222222222222222222222222222";
+const MILADY = "0x8b3bc6942d6823a8022605648b671a2feb954800";
+const HOOK = PairedTokenPositionManagerV1_3Address[mainnet.id];
+const ANY_HOOK = AnyPositionManagerV1_3Address[mainnet.id];
+const TX_HASH = `0x${"01".repeat(32)}`;
+
+function harness(hook = HOOK, pairedToken = zeroAddress) {
+  const calls = [];
+  const key = pairedPoolKey(COIN, pairedToken, hook);
+  const drift = {
+    contract({ address, abi }) {
+      return {
+        address,
+        async read(fn, args) {
+          calls.push({ kind: "read", address, fn, args });
+          if (fn === "poolKey") return address.toLowerCase() === hook.toLowerCase() && args._token.toLowerCase() === COIN
+            ? key : { ...key, tickSpacing: 0, hooks: zeroAddress };
+          if (fn === "flaunchContract") return hook === ANY_HOOK ? RELEASE_ADDRESSES.AnyFlaunchV1_3Address : RELEASE_ADDRESSES.FlaunchV1_3Address;
+          if (fn === "tokenId") return 7n;
+          if (fn === "getFlaunchingMarketCap") return 4n * 10n ** 18n;
+          if (fn === "initialPrice") return "0x8FAaCFd24B6EaAa4e51DE1686930fbF4b5Fa8ab0";
+          if (fn === "getFlaunchingFee") return 100n;
+          if (fn === "calculateFee") return { ethRequired_: 123n, pairedPremineCost_: 0n };
+          if (fn === "getSlot0") return { sqrtPriceX96: 0n, tick: 100, protocolFee: 0, lpFee: 0 };
+          throw new Error(`Unexpected read ${fn}`);
+        },
+        async write(fn, args, options) {
+          calls.push({ kind: "write", address, abi, fn, args, options });
+          return TX_HASH;
+        },
+      };
+    },
+  };
+  return { calls, key, sdk: new ReadWriteFlaunchSDK(mainnet.id, drift), drift };
+}
+
+test("Ethereum maps match the verified deployment and keep legacy/default pairings separate", () => {
+  for (const [name, address] of Object.entries(RELEASE_ADDRESSES)) {
+    assert.equal(getAddress(sdkExports[name][mainnet.id]), getAddress(address), name);
+  }
+  assert.equal(DefaultPairedTokenAddress[mainnet.id], zeroAddress);
+  assert.equal(FLETHAddress[mainnet.id], "0x000000000bB1f9944965c64066D10038a84F9af2");
+  for (const chain of [base, baseSepolia, robinhood, unichain]) {
+    assert.equal(DefaultPairedTokenAddress[chain.id], FLETHAddress[chain.id]);
+  }
+  assert.deepEqual(getV1_3PositionManagers(mainnet.id), [HOOK, ANY_HOOK]);
+  assert.equal(getPermissionsAddressV1_3(Permissions.CLOSED, mainnet.id), RELEASE_ADDRESSES.ClosedPermissionsV1_3Address);
+  assert.equal(getPermissionsAddressV1_3(Permissions.WHITELISTED, mainnet.id), RELEASE_ADDRESSES.WhitelistedPermissionsV1_3Address);
+  assert.equal(sdkExports.QuoterAddress[mainnet.id], "0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203");
+  assert.equal(sdkExports.Permit2Address[mainnet.id], "0x000000000022D473030F116dDEE9F6B43aC78BA3");
+});
+
+test("native fee and USD helpers use current contracts and correct denominations", async () => {
+  const { sdk, calls } = harness();
+  assert.equal(await sdk.getETHUSDCPrice(), 2500);
+  assert.equal(await sdk.getFlaunchingFee({ sender: CREATOR, initialMarketCapUSD: 10_000, slippagePercent: 5 }), 105n);
+  assert.equal(await sdk.ethRequiredToFlaunch({ premineAmount: 5n, initialMarketCapUSD: 10_000, slippagePercent: 2 }), 123n);
+  const price = calls.find(({ fn }) => fn === "getFlaunchingMarketCap");
+  assert.equal(price.address, HOOK);
+  assert.deepEqual(decodeAbiParameters([{ type: "uint256" }], price.args._initialPriceParams), [10_000_000_000n]);
+  const quote = calls.find(({ fn }) => fn === "calculateFee");
+  assert.equal(quote.address, FlaunchZapV1_3Address[mainnet.id]);
+  assert.equal(quote.args._flaunchParams.pairedToken, zeroAddress);
+  assert.equal(quote.args._flaunchParams.premineAmount, 5n);
+  assert.equal(quote.args._slippage, 200n);
+});
+
+test("paired-token manager launches retain the caller's cap, funding and manager tuple", async () => {
+  const { sdk, calls } = harness();
+  const flaunchParams = {
+    name: "Test", symbol: "TEST", tokenUri: "ipfs://test", premineAmount: 100n,
+    creator: CREATOR, creatorFeeAllocation: 10_000, flaunchAt: 0n,
+    initialPriceParams: encodeAbiParameters([{ type: "uint256" }], [10_000_000_000n]),
+    feeCalculatorParams: "0x", pairedToken: MILADY,
+  };
+  const treasuryManagerParams = {
+    manager: RELEASE_ADDRESSES.DynamicAddressFeeSplitManagerV1_3Address,
+    permissions: RELEASE_ADDRESSES.WhitelistedPermissionsV1_3Address,
+    initializeData: "0x1234", depositData: "0xabcd",
+  };
+  await sdk.flaunchPairedToken({ flaunchParams, treasuryManagerParams, trustedFeeSigner: zeroAddress, maxPremineCost: 456n, value: 123n });
+  const call = calls.find(({ kind }) => kind === "write");
+  assert.equal(call.address, FlaunchZapV1_3Address[mainnet.id]);
+  assert.deepEqual(call.args, { _flaunchParams: flaunchParams, _treasuryManagerParams: treasuryManagerParams, _trustedFeeSigner: zeroAddress, _maxPremineCost: 456n });
+  assert.equal(call.options.value, 123n);
+  // Test the actual overload encoding, not only the recorded named arguments.
+  const { encodeFunctionData } = require("viem");
+  const decoded = decodeFunctionData({ abi: FlaunchZapV1_3Abi, data: encodeFunctionData({
+    abi: call.abi, functionName: call.fn, args: [flaunchParams, treasuryManagerParams, zeroAddress, 456n],
+  }) });
+  assert.equal(decoded.args.length, 4);
+  assert.equal(decoded.args[3], 456n);
+});
+
+test("current AnyPositionManager pools resolve their actual pool and NFT contract", async () => {
+  const { sdk, key } = harness(ANY_HOOK, MILADY);
+  assert.equal(await sdk.getCoinVersion(COIN), FlaunchVersion.V1_3);
+  assert.equal(await sdk.getPositionManagerAddressForCoin(COIN), ANY_HOOK);
+  assert.equal(await sdk.poolId(COIN), getPoolId(key));
+  assert.deepEqual(await sdk.getFlaunchTokenIdForMemecoin(COIN), {
+    flaunchAddress: RELEASE_ADDRESSES.AnyFlaunchV1_3Address, tokenId: 7n,
+  });
+  await assert.rejects(() => sdk.coinPriceInETH(COIN), /ERC20-paired coin prices require conversion/);
+});
+
+test("native ETH coin prices read the actual pool and invert its nonzero tick", async () => {
+  const { sdk, key, calls } = harness();
+  const price = await sdk.coinPriceInETH(COIN);
+  assert.match(price, /^\d+\.\d{18}$/);
+  assert.ok(Math.abs(Number(price) - 0.9900503287412106) < 1e-15);
+  const state = calls.find(({ fn }) => fn === "getSlot0");
+  assert.equal(state.address, sdkExports.StateViewAddress[mainnet.id]);
+  assert.equal(state.args.poolId, getPoolId(key));
+});
+
+test("current imported PoolCreated receipts preserve the paired token and ignore other emitters", () => {
+  const { sdk, key } = harness(ANY_HOOK, MILADY);
+  const params = { memecoin: COIN, creator: CREATOR, creatorFeeAllocation: 10_000, initialPriceParams: "0x1234", feeCalculatorParams: "0x", pairedToken: MILADY };
+  // Independent schema from flaunch-contracts v1.4.0 IAnyPositionManager.sol:29,72.
+  const contractEventAbi = parseAbi([
+    "event PoolCreated(bytes32 indexed _poolId, address _memecoin, address _memecoinTreasury, uint256 _tokenId, bool _currencyFlipped, (address memecoin, address creator, uint24 creatorFeeAllocation, bytes initialPriceParams, bytes feeCalculatorParams, address pairedToken) _params)",
+  ]);
+  const event = contractEventAbi[0];
+  const log = {
+    address: ANY_HOOK,
+    topics: encodeEventTopics({ abi: contractEventAbi, eventName: "PoolCreated", args: { _poolId: getPoolId(key) } }),
+    data: encodeAbiParameters(event.inputs.filter(({ indexed }) => !indexed), [COIN, TREASURY, 7n, false, params]),
+  };
+  assert.equal(sdk.getPoolCreatedFromLogs([{ ...log, address: CREATOR }]), null);
+  const parsed = sdk.getPoolCreatedFromLogs([log]);
+  assert.equal(parsed.memecoin.toLowerCase(), COIN);
+  assert.equal(parsed.tokenId, 7n);
+  assert.equal(parsed.params.pairedToken.toLowerCase(), MILADY);
+  assert.equal(parsed.params.creator, CREATOR);
+  assert.equal(parsed.params.name, "");
+});
+
+test("legacy flETH swap entry points refuse current Ethereum pools before any simulation or write", async () => {
+  const { sdk, calls } = harness();
+  for (const operation of [
+    () => sdk.getBuyQuoteExactInput({ coinAddress: COIN, amountIn: 100n }),
+    () => sdk.getBuyQuoteExactOutput({ coinAddress: COIN, amountOut: 100n }),
+    () => sdk.getSellQuoteExactInput({ coinAddress: COIN, amountIn: 100n }),
+    () => sdk.buyCoin({ coinAddress: COIN, amountIn: 100n, swapType: "EXACT_IN", slippagePercent: 1 }),
+    () => sdk.sellCoin({ coinAddress: COIN, amountIn: 100n, slippagePercent: 1 }),
+  ]) {
+    await assert.rejects(operation, /protected paired-token swap API/);
+  }
+  assert.ok(calls.every(({ fn }) => fn === "poolKey"));
+});

--- a/test/feeEscrowV1_3.test.cjs
+++ b/test/feeEscrowV1_3.test.cjs
@@ -9,7 +9,7 @@ const {
   toHex,
   zeroAddress,
 } = require("viem");
-const { base, mainnet } = require("viem/chains");
+const { base, mainnet, unichain } = require("viem/chains");
 const {
   createFlaunchCalldata,
   decodeCallData,
@@ -123,14 +123,38 @@ test("creatorRevenueByToken reads balances(recipient, token) per escrow token", 
 
 test("chains without the multi-token escrow say so before anything is sent", async () => {
   assert.equal(doesChainSupportMultiTokenFeeEscrow(base.id), true);
-  assert.equal(doesChainSupportMultiTokenFeeEscrow(mainnet.id), false);
+  assert.equal(doesChainSupportMultiTokenFeeEscrow(unichain.id), false);
 
   const sdk = createFlaunchCalldata({
-    publicClient: publicClientFor(mainnet, () => "0x"),
+    publicClient: publicClientFor(unichain, () => "0x"),
     walletAddress: CREATOR,
   });
   await assert.rejects(
     () => sdk.withdrawCreatorRevenueByToken({ tokens: [zeroAddress] }),
-    /Multi-token FeeEscrow is not supported on chain 1/
+    /Multi-token FeeEscrow is not supported on chain 130/
   );
+});
+
+test("Ethereum reads and claims native ETH and NFTX token fees from the current escrow", async () => {
+  const tokens = [zeroAddress, "0x8b3bc6942d6823a8022605648b671a2feb954800", "0x370e49749b9ff90004f3186aa7135487acc2a8fc"];
+  const calls = [];
+  const sdk = createFlaunchCalldata({
+    publicClient: publicClientFor(mainnet, (call) =>
+      answerReads(call, calls, encodeAbiParameters([{ type: "uint256" }], [123n]))
+    ),
+    walletAddress: CREATOR,
+  });
+  assert.equal(doesChainSupportMultiTokenFeeEscrow(mainnet.id), true);
+  assert.deepEqual(
+    await sdk.creatorRevenueByToken({ creator: CREATOR, tokens }),
+    tokens.map((token) => ({ token, amount: 123n }))
+  );
+  assert.equal(calls.length, 3);
+  assert.ok(calls.every((call) => call.to.toLowerCase() === FeeEscrowV1_3Address[mainnet.id].toLowerCase()));
+  const transaction = decodeCallData(await sdk.withdrawCreatorRevenueByToken({ tokens }));
+  assert.equal(transaction.to.toLowerCase(), FeeEscrowV1_3Address[mainnet.id].toLowerCase());
+  const decoded = decodeFunctionData({ abi: FeeEscrowV1_3Abi, data: transaction.data });
+  assert.deepEqual(decoded.args[0].map((token) => token.toLowerCase()), tokens);
+  assert.equal(decoded.args[1], CREATOR);
+  assert.equal(decoded.args[2], true);
 });

--- a/test/managersV1_3.test.cjs
+++ b/test/managersV1_3.test.cjs
@@ -12,7 +12,7 @@ const {
   toHex,
   zeroAddress,
 } = require("viem");
-const { base, robinhood, baseSepolia, mainnet } = require("viem/chains");
+const { base, robinhood, baseSepolia, mainnet, unichain } = require("viem/chains");
 const {
   createFlaunchCalldata,
   decodeCallData,
@@ -149,12 +149,12 @@ function decodeBalancesArgs(call) {
   return decodeFunctionData({ abi: TreasuryManagerV1_3Abi, data: call.data }).args;
 }
 
-test("the v1.3.1 manager generation is pinned to the Base, Robinhood and Base Sepolia releases and absent elsewhere", () => {
+test("the multi-asset manager generation retains the Base, Robinhood and Base Sepolia releases", () => {
   for (const [name, [map, expectedBase, expectedRobinhood]] of Object.entries(RELEASE_ADDRESSES)) {
     assert.deepEqual(
       Object.keys(map).sort(),
-      [String(robinhood.id), String(base.id), String(baseSepolia.id)].sort(),
-      `${name} should be Base + Robinhood + Base Sepolia only`
+      [String(robinhood.id), String(base.id), String(baseSepolia.id), String(mainnet.id)].sort(),
+      `${name} should include Ethereum and the existing deployments`
     );
     assert.equal(getAddress(map[base.id]), getAddress(expectedBase), name);
     assert.equal(getAddress(map[robinhood.id]), getAddress(expectedRobinhood), name);
@@ -182,13 +182,13 @@ test("the v1.3.1 manager generation is pinned to the Base, Robinhood and Base Se
   assert.equal(SupersededPositionManagerV1_3Address[base.id], undefined);
   assert.deepEqual(
     getV1_3PositionManagers(robinhood.id).map((a) => a.toLowerCase()),
-    [FlaunchPositionManagerV1_3Address[robinhood.id].toLowerCase(), "0x588c683ecc450f8b2aadb13d7f63792b840425dc", "0x6ea0edee449a287504990df8d87951b9436825dc"]
+    [FlaunchPositionManagerV1_3Address[robinhood.id].toLowerCase(), "0x9abfbdc34a294de5210c0889f21d5af54c4965dc", "0x588c683ecc450f8b2aadb13d7f63792b840425dc", "0x6ea0edee449a287504990df8d87951b9436825dc"]
   );
   assert.equal(doesChainSupportMultiAssetManagers(robinhood.id), true);
 
   assert.equal(doesChainSupportMultiAssetManagers(base.id), true);
   assert.equal(doesChainSupportMultiAssetManagers(baseSepolia.id), true); // since 2026-09-03
-  assert.equal(doesChainSupportMultiAssetManagers(mainnet.id), false);
+  assert.equal(doesChainSupportMultiAssetManagers(mainnet.id), true);
 });
 
 test("v1.3.1 permissions map WHITELISTED to the factory-bound instance and leave the old mapping alone", () => {
@@ -458,7 +458,7 @@ test("revenueManagerPayoutAssets and treasuryManagerBalancesV1_3 enumerate the m
 });
 
 test("chains without the v1.3.1 manager generation say so before anything is sent", async () => {
-  for (const chain of [mainnet]) {
+  for (const chain of [unichain]) {
     const requests = [];
     const sdk = calldataSdk(chain, (call) => {
       requests.push(call);

--- a/test/multichainLaunch.test.cjs
+++ b/test/multichainLaunch.test.cjs
@@ -12,9 +12,13 @@ const {
 const { base, mainnet, robinhood, unichain } = require("viem/chains");
 const {
   AddressFeeSplitManagerAddress,
+  AddressFeeSplitManagerV1_3Address,
   DynamicAddressFeeSplitManagerAddress,
+  DynamicAddressFeeSplitManagerV1_3Address,
   FlaunchZapAbi,
   FlaunchZapMultichainAddress,
+  FlaunchZapV1_3Abi,
+  FlaunchZapV1_3Address,
   createFlaunchCalldata,
   decodeCallData,
 } = require("../dist/index.cjs.js");
@@ -36,6 +40,9 @@ const params = {
 };
 
 function multichainHarness(chain) {
+  const nativeDefault = chain.id === mainnet.id;
+  const abi = nativeDefault ? FlaunchZapV1_3Abi : FlaunchZapAbi;
+  const zapAddress = nativeDefault ? FlaunchZapV1_3Address[chain.id] : FlaunchZapMultichainAddress[chain.id];
   const ethCalls = [];
   let requestCount = 0;
   const publicClient = createPublicClient({
@@ -49,11 +56,13 @@ function multichainHarness(chain) {
           ethCalls.push({
             transaction,
             decoded: decodeFunctionData({
-              abi: FlaunchZapAbi,
+              abi,
               data: transaction.data,
             }),
           });
-          return encodeAbiParameters([{ type: "uint256" }], [FEE]);
+          return nativeDefault
+            ? encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [FEE, 0n])
+            : encodeAbiParameters([{ type: "uint256" }], [FEE]);
         }
         throw new Error(`Unexpected RPC request: ${method}`);
       },
@@ -61,6 +70,9 @@ function multichainHarness(chain) {
   });
 
   return {
+    abi,
+    zapAddress,
+    nativeDefault,
     ethCalls,
     get requestCount() {
       return requestCount;
@@ -82,7 +94,7 @@ test("multichain launches encode the canonical tuple on all three chains", async
       const feeCall = harness.ethCalls[0];
       assert.equal(
         feeCall.transaction.to.toLowerCase(),
-        FlaunchZapMultichainAddress[chain.id].toLowerCase()
+        harness.zapAddress.toLowerCase()
       );
       assert.equal(feeCall.decoded.functionName, "calculateFee");
       assert.equal(feeCall.decoded.args[1], 500n);
@@ -98,11 +110,13 @@ test("multichain launches encode the canonical tuple on all three chains", async
         "flaunchAt",
         "initialPriceParams",
         "feeCalculatorParams",
+        ...(harness.nativeDefault ? ["pairedToken"] : []),
       ]);
       assert.equal(feeParams.premineAmount, 42n);
       assert.equal(feeParams.flaunchAt, 123n);
       assert.equal(feeParams.creatorFeeAllocation, 110);
       assert.equal(feeParams.feeCalculatorParams, "0x");
+      if (harness.nativeDefault) assert.equal(feeParams.pairedToken, zeroAddress);
       assert.equal(
         decodeAbiParameters(
           [{ type: "uint256" }],
@@ -114,21 +128,22 @@ test("multichain launches encode the canonical tuple on all three chains", async
       const transaction = decodeCallData(encodedCall);
       assert.equal(
         transaction.to.toLowerCase(),
-        FlaunchZapMultichainAddress[chain.id].toLowerCase()
+        harness.zapAddress.toLowerCase()
       );
       assert.equal(transaction.value, FEE);
       const flaunchCall = decodeFunctionData({
-        abi: FlaunchZapAbi,
+        abi: harness.abi,
         data: transaction.data,
       });
       assert.equal(flaunchCall.functionName, "flaunch");
       assert.deepEqual(flaunchCall.args[0], feeParams);
       assert.equal(flaunchCall.args[1], zeroAddress);
+      if (harness.nativeDefault) assert.equal(flaunchCall.args[2], 0n);
     });
   }
 });
 
-test("multichain dynamic split launches encode the v1.2.2 manager overload", async (t) => {
+test("multichain dynamic split launches select the chain's current manager generation", async (t) => {
   const secondRecipient = "0x2222222222222222222222222222222222222222";
 
   for (const chain of multichainDeploymentChains) {
@@ -150,12 +165,12 @@ test("multichain dynamic split launches encode the v1.2.2 manager overload", asy
       const transaction = decodeCallData(encodedCall);
       assert.equal(
         transaction.to.toLowerCase(),
-        FlaunchZapMultichainAddress[chain.id].toLowerCase()
+        harness.zapAddress.toLowerCase()
       );
       assert.equal(transaction.value, FEE);
 
       const flaunchCall = decodeFunctionData({
-        abi: FlaunchZapAbi,
+        abi: harness.abi,
         data: transaction.data,
       });
       assert.equal(flaunchCall.functionName, "flaunch");
@@ -163,11 +178,13 @@ test("multichain dynamic split launches encode the v1.2.2 manager overload", asy
       const managerParams = flaunchCall.args[1];
       assert.equal(
         managerParams.manager.toLowerCase(),
-        DynamicAddressFeeSplitManagerAddress[chain.id].toLowerCase()
+        (harness.nativeDefault ? DynamicAddressFeeSplitManagerV1_3Address : DynamicAddressFeeSplitManagerAddress)[chain.id].toLowerCase()
       );
       assert.equal(managerParams.permissions, zeroAddress);
       assert.equal(managerParams.depositData, "0x");
       assert.equal(flaunchCall.args[2], zeroAddress);
+      assert.equal(flaunchCall.args.length, harness.nativeDefault ? 4 : 3);
+      if (harness.nativeDefault) assert.equal(flaunchCall.args[3], 0n);
 
       const [initializeParams] = decodeAbiParameters(
         [
@@ -243,19 +260,17 @@ test("multichain revenue manager launches deposit into the existing instance", a
       const transaction = decodeCallData(encodedCall);
       assert.equal(
         transaction.to.toLowerCase(),
-        FlaunchZapMultichainAddress[chain.id].toLowerCase()
+        harness.zapAddress.toLowerCase()
       );
       assert.equal(transaction.value, FEE);
 
       const flaunchCall = decodeFunctionData({
-        abi: FlaunchZapAbi,
+        abi: harness.abi,
         data: transaction.data,
       });
       assert.equal(flaunchCall.functionName, "flaunch");
-      // Three arguments means the treasury-manager overload was selected. The
-      // two-argument overload would encode a valid call that silently drops
-      // the manager.
-      assert.equal(flaunchCall.args.length, 3);
+      // The current Ethereum overload also carries the explicit premine cost cap.
+      assert.equal(flaunchCall.args.length, harness.nativeDefault ? 4 : 3);
 
       const managerParams = flaunchCall.args[1];
       assert.equal(managerParams.manager, revenueManagerInstanceAddress);
@@ -285,15 +300,15 @@ test("multichain static split launches deploy the AddressFeeSplitManager", async
       });
 
       const flaunchCall = decodeFunctionData({
-        abi: FlaunchZapAbi,
+        abi: harness.abi,
         data: decodeCallData(encodedCall).data,
       });
-      assert.equal(flaunchCall.args.length, 3);
+      assert.equal(flaunchCall.args.length, harness.nativeDefault ? 4 : 3);
 
       const managerParams = flaunchCall.args[1];
       assert.equal(
         managerParams.manager.toLowerCase(),
-        AddressFeeSplitManagerAddress[chain.id].toLowerCase()
+        (harness.nativeDefault ? AddressFeeSplitManagerV1_3Address : AddressFeeSplitManagerAddress)[chain.id].toLowerCase()
       );
 
       const [initializeParams] = decodeAbiParameters(
@@ -393,20 +408,20 @@ test("every multichain IPFS entry point preserves its manager and uploaded URI",
     const cases = [
       ["flaunchIPFS", params, undefined],
       ["flaunchIPFSWithRevenueManager", { ...params, revenueManagerInstanceAddress }, revenueManagerInstanceAddress],
-      ["flaunchIPFSWithSplitManager", staticSplit, AddressFeeSplitManagerAddress[chain.id]],
+      ["flaunchIPFSWithSplitManager", staticSplit, (chain.id === mainnet.id ? AddressFeeSplitManagerV1_3Address : AddressFeeSplitManagerAddress)[chain.id]],
       ["flaunchIPFSWithDynamicSplitManager", {
         ...params, creatorShare: 2_000_000n, managerOwnerShare: 0n,
         moderator: CREATOR, splitReceivers: [{ address: CREATOR, share: 10_000_000n }],
-      }, DynamicAddressFeeSplitManagerAddress[chain.id]],
+      }, (chain.id === mainnet.id ? DynamicAddressFeeSplitManagerV1_3Address : DynamicAddressFeeSplitManagerAddress)[chain.id]],
     ];
     for (const [method, input, manager] of cases) {
-      const { sdk } = multichainHarness(chain);
+      const { sdk, abi, nativeDefault } = multichainHarness(chain);
       const call = decodeCallData(await sdk[method]({
         ...input, metadata: { base64Image: "aW1hZ2U=", description: "Test" },
       }));
-      const decoded = decodeFunctionData({ abi: FlaunchZapAbi, data: call.data });
+      const decoded = decodeFunctionData({ abi, data: call.data });
       assert.equal(decoded.args[0].tokenUri, "ipfs://test-cid");
-      assert.equal(decoded.args.length, manager ? 3 : 2);
+      assert.equal(decoded.args.length, (manager ? 3 : 2) + (nativeDefault ? 1 : 0));
       if (manager) assert.equal(decoded.args[1].manager.toLowerCase(), manager.toLowerCase());
     }
   }

--- a/test/pairedTokenLaunch.test.cjs
+++ b/test/pairedTokenLaunch.test.cjs
@@ -8,7 +8,7 @@ const {
   toFunctionSelector,
   zeroAddress,
 } = require("viem");
-const { base, baseSepolia, mainnet, robinhood } = require("viem/chains");
+const { base, baseSepolia, mainnet, robinhood, unichain } = require("viem/chains");
 const {
   FlaunchPositionManagerV1_3Abi,
   FlaunchPositionManagerV1_3Address,
@@ -73,7 +73,7 @@ function recordingDrift({ approved = true, quote } = {}) {
 }
 
 test("paired-token launch addresses and capability cover deployed V1.3 chains", () => {
-  const supportedChains = [base.id, baseSepolia.id, robinhood.id];
+  const supportedChains = [base.id, baseSepolia.id, robinhood.id, mainnet.id];
 
   for (const chainId of supportedChains) {
     assert.ok(FlaunchZapV1_3Address[chainId]);
@@ -82,7 +82,7 @@ test("paired-token launch addresses and capability cover deployed V1.3 chains", 
     assert.equal(doesChainSupportPairedTokenLaunch(chainId), true);
   }
 
-  assert.equal(doesChainSupportPairedTokenLaunch(mainnet.id), false);
+  assert.equal(doesChainSupportPairedTokenLaunch(unichain.id), false);
   assert.equal(doesChainSupportPairedTokenLaunch(999_999), false);
   // Base Sepolia gained a full v1.3 generation on 2026-09-03 (v1.3.3 regeneration)
   assert.equal(FlaunchPositionManagerV1_3Address[baseSepolia.id].toLowerCase(), "0x8d346f24278c5cd786309161aac0fc2bbe4c25dc");
@@ -207,10 +207,10 @@ test("SDK facades expose paired-token clients on Robinhood and guard unsupported
     TX_HASH
   );
 
-  const unsupported = new ReadFlaunchSDK(mainnet.id, drift);
+  const unsupported = new ReadFlaunchSDK(unichain.id, drift);
   assert.throws(
     () => unsupported.isPairedTokenApproved(PAIRED_TOKEN),
-    /Paired-token launches are not supported on chain 1/
+    /Paired-token launches are not supported on chain 130/
   );
 });
 

--- a/test/pairedTokenSwap.test.cjs
+++ b/test/pairedTokenSwap.test.cjs
@@ -6,11 +6,12 @@ const {
   encodeAbiParameters,
   zeroAddress,
 } = require("viem");
-const { base, baseSepolia, mainnet, robinhood } = require("viem/chains");
+const { base, baseSepolia, mainnet, robinhood, unichain } = require("viem/chains");
 const {
   MAX_SQRT_PRICE_LIMIT,
   MIN_SQRT_PRICE_LIMIT,
   PairedTokenPositionManagerV1_3Address,
+  AnyPositionManagerV1_3Address,
   PoolSwapV1_3Abi,
   QuoterAbi,
   PoolSwapV1_3Address,
@@ -150,11 +151,11 @@ function recordingDrift({
 }
 
 test("paired-token swap addresses and capability cover the deployed V1.3 chains", () => {
-  for (const chainId of [base.id, baseSepolia.id, robinhood.id]) {
+  for (const chainId of [base.id, baseSepolia.id, robinhood.id, mainnet.id]) {
     assert.ok(PoolSwapV1_3Address[chainId], `PoolSwap on ${chainId}`);
     assert.equal(doesChainSupportPairedTokenSwap(chainId), true);
   }
-  assert.equal(doesChainSupportPairedTokenSwap(mainnet.id), false);
+  assert.equal(doesChainSupportPairedTokenSwap(unichain.id), false);
   // Sepolia's protected router is approved by both deployed gate generations.
   assert.equal(
     PoolSwapV1_3Address[baseSepolia.id].toLowerCase(),
@@ -505,7 +506,7 @@ test("buyCoinPairedToken sends approve then swap through the write clients", asy
 
 test("paired-token swaps refuse chains without the deployment", async () => {
   const { drift } = recordingDrift();
-  const sdk = new ReadFlaunchSDK(mainnet.id, drift);
+  const sdk = new ReadFlaunchSDK(unichain.id, drift);
   await assert.rejects(
     () =>
       sdk.planPairedTokenSwap({
@@ -514,9 +515,39 @@ test("paired-token swaps refuse chains without the deployment", async () => {
         slippageBps: 50,
         direction: "buy",
       }),
-    /not supported on chain 1/,
+    /not supported on chain 130/,
   );
   assert.throws(() => sdk.readPoolSwapV1_3, /not supported/);
+});
+
+test("Ethereum ETH, MILADY and LIL plans use the protected router for both current hooks", async (t) => {
+  const router = PoolSwapV1_3Address[mainnet.id];
+  const tokens = [zeroAddress, "0x8b3bc6942d6823a8022605648b671a2feb954800", "0x370e49749b9ff90004f3186aa7135487acc2a8fc"];
+  for (const hook of [PairedTokenPositionManagerV1_3Address[mainnet.id], AnyPositionManagerV1_3Address[mainnet.id]]) {
+    for (const token of tokens) {
+      await t.test(`${hook} / ${token}`, async () => {
+        const poolKey = pairedPoolKey(COIN, token, hook);
+        const { drift } = recordingDrift({ poolKey, answeringHook: hook });
+        const sdk = new ReadFlaunchSDK(mainnet.id, drift);
+        for (const direction of ["buy", "sell"]) {
+          const plan = await sdk.planPairedTokenSwap({
+            coinAddress: COIN, amountIn: 10_000n, slippageBps: 100,
+            sender: SENDER, direction,
+          });
+          assert.deepEqual(plan.poolKey, poolKey);
+          assert.equal(plan.swap.to.toLowerCase(), router.toLowerCase());
+          assert.equal(plan.amountOutMin, 9_801n);
+          assert.equal(plan.swap.value, direction === "buy" && token === zeroAddress ? 10_000n : 0n);
+          if (direction === "buy" && token === zeroAddress) {
+            assert.equal(plan.approve, undefined);
+          } else {
+            assert.equal(plan.approve.spender.toLowerCase(), router.toLowerCase());
+            assert.equal(plan.approve.token.toLowerCase(), (direction === "buy" ? token : COIN).toLowerCase());
+          }
+        }
+      });
+    }
+  }
 });
 
 test("registry tokenConfig exposes decimals and type; clients construct", async () => {


### PR DESCRIPTION
## Summary

Support the deployed Ethereum v1.4.0 contracts, native ETH launches and protected exact-input swaps, plus the approved MILADY and LIL pairings. Preserve existing Base and other-chain behavior.

Update current-generation manager launches, imported-token reads, pricing and token-specific creator fee claims. Document the deployment addresses and supported execution paths.

`@flaunch/sdk@0.15.0` is already published as npm `latest`; the registry integrity matches the tested package.

## Verification

- TypeScript and the production package build pass.
- All 145 tests pass.
- Packed-package consumers pass for all six exports in CommonJS/ESM and TypeScript NodeNext/Bundler modes.
- Dependency audit reports no known vulnerabilities.
- No mainnet transactions were broadcast.

## Rollout

Merge this first, followed by the backend, Web2 API, UI and MCP consumer PRs. Envio is already updated and synced. Consumers use the published SDK version, so no further npm publish is needed.
